### PR TITLE
Fix permissions for hands

### DIFF
--- a/meta-narwhal/recipes-android/android-init/android-init/init.rc
+++ b/meta-narwhal/recipes-android/android-init/android-init/init.rc
@@ -8,7 +8,13 @@ on init
     mkdir /dev/graphics/
     symlink /dev/fb0 /dev/graphics/fb0
     chown system root /sys/class/timed_output/vibrator/enable
-    chmod 666 /sys/devices/sop716/*
+
+    chmod 222 /sys/devices/sop716/motor_move_all
+    chmod 222 /sys/devices/sop716/motor_move
+    chmod 222 /sys/devices/sop716/motor_init
+    chmod 666 /sys/devices/sop716/watch_mode
+    chmod 444 /sys/devices/sop716/position
+    chmod 666 /sys/devices/sop716/self_test
 
     load_system_props
     restorecon_recursive /persist


### PR DESCRIPTION
It seems that the permission to execute is also needed for all users to have control of the hands. This fixes this. This change is necessary for the PhysicalHands module  (an extension of qml-asteroid to support the physical hands, which I will upstream very soon) to work