### PR TITLE
Load WiFi kernel module and adjust bootlogo size

### DIFF
--- a/meta-sparrow/conf/machine/sparrow.conf
+++ b/meta-sparrow/conf/machine/sparrow.conf
@@ -13,4 +13,6 @@ PREFERRED_VERSION_android = "lollipop"
 PREFERRED_PROVIDER_virtual/kernel = "linux-sparrow"
 PREFERRED_VERSION_linux = "3.10+marshmallow"
 
+KERNEL_MODULE_AUTOLOAD += "bcmdhd"
+
 IMAGE_INSTALL += "msm-fb-refresher brcm-patchram-plus underclock"

--- a/meta-sparrow/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-sparrow/recipes-core/psplash/psplash_git.bbappend
@@ -1,1 +1,4 @@
-SPLASH_IMAGES = "file://psplash-img-320.png;outsuffix=default"
+do_install:append:sparrow() {
+    install -d ${D}/usr/share/
+    install -m 0755 ${WORKDIR}/psplash-img-320-176.gif ${D}/usr/share/psplash.gif
+}


### PR DESCRIPTION
This automatically loads the kernel module needed to expose a WiFi interface, but it's still disabled/soft-blocked by default (this is good, it means that it doesn't scan for WiFi access points by default).

Additionally, adjust the animated bootlogo so that it matches the screen resolution. This should lead to a clean transition from the bootlogo to the splash animation in the launcher.

Thanks to @eLtMosen for testing these things :smile: