### PR TITLE
Copy nanaohub bin and build.prop from the original WearOS

### DIFF
--- a/meta-catfish/recipes-android/android/android_catfish-n.bb
+++ b/meta-catfish/recipes-android/android/android_catfish-n.bb
@@ -12,6 +12,7 @@ SRC_URI[hybris.sha256sum] = "626bed275cfe2df2377e709498fc26d58e7883045cd13d4e2a6
 SRC_URI[system.md5sum] = "9082d05811e4ce93efa291a41fd61360"
 SRC_URI[system.sha256sum] = "3c28f9e4579e37c100a24d7d9c693b813b1c90eabf495c5761b855d2f5169708"
 PV = "oreo"
+PR = "r1"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 INHIBIT_PACKAGE_STRIP = "1"
@@ -19,6 +20,8 @@ COMPATIBLE_MACHINE = "catfish"
 INSANE_SKIP:${PN} = "already-stripped"
 S = "${WORKDIR}"
 B = "${S}"
+
+DEPENDS += "rsync-native"
 
 PROVIDES += "virtual/android-system-image"
 PROVIDES += "virtual/android-headers"
@@ -39,10 +42,12 @@ do_install() {
     rm ${D}${includedir}/android/android-headers.pc
 
     install -d ${D}/system/
-    cp -r system/* ${D}/system/
+    # FIXME: Remove these files from the blob
+    rsync -a --delete \
+      --exclude=vendor/firmware/nanohub.full.*.bin --exclude=build.prop --exclude=vendor/build.prop \
+      system/* ${D}/system/
 
-    cd ${D}
-    ln -s system/vendor vendor
+    ln -s system/vendor ${D}/vendor
 }
 
 # FIXME: QA Issue: Architecture did not match (40 to 164) on /work/dory-oe-linux-gnueabi/android/lollipop-r0/packages-split/android-system/system/vendor/firmware/adsp.b00 [arch]

--- a/meta-catfish/recipes-core/initrdscripts/initramfs-scripts-android/init.machine.sh
+++ b/meta-catfish/recipes-core/initrdscripts/initramfs-scripts-android/init.machine.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+BOOT_DIR=$1
+
+if [ ! -e $BOOT_DIR/system/build.prop ] ; then
+    mkdir -p /tmp/vendor
+    mkdir -p /tmp/system
+    mount -t ext4 -o ro /dev/mmcblk0p31 /tmp/vendor
+    mount -t ext4 -o ro /dev/mmcblk0p22 /tmp/system
+
+    cp /tmp/vendor/firmware/nanohub.full.*.bin $BOOT_DIR/system/vendor/firmware/
+    cp /tmp/vendor/build.prop $BOOT_DIR/system/vendor/
+    cp /tmp/system/build.prop $BOOT_DIR/system/
+fi

--- a/meta-catfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-catfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -1,4 +1,14 @@
 FILESEXTRAPATHS:prepend:catfish := "${THISDIR}/${PN}:"
 COMPATIBLE_MACHINE:catfish = "catfish"
 
+PR = "r1"
+
 RDEPENDS:${PN}:append:catfish += "msm-fb-refresher"
+
+SRC_URI:append:catfish = " file://init.machine.sh"
+
+do_install:append:catfish() {
+    install -m 0755 ${WORKDIR}/init.machine.sh ${D}/init.machine
+}
+
+FILES:${PN} += "/init.machine"


### PR DESCRIPTION
- This should limit the times the MCU is being flashed, assuming it does not trigger a flash if the firmware versions are the same.
  - [ ] Test by running `/vendor/bin/nanohubapp_cmd download`
- The specific watch can now be queried via `getprop`
- Some files can be removed from the blob `build.prop` and `nanohub.full.*.bin`