### PR TITLE
Removed service updating nanohub from init.rc

### DIFF
--- a/meta-catfish/recipes-android/android-init/android-init/init.rc
+++ b/meta-catfish/recipes-android/android-init/android-init/init.rc
@@ -55,7 +55,3 @@ service hwservicemanager /system/bin/hwservicemanager
 service bt /vendor/bin/hw/android.hardware.bluetooth@1.0-service
     class core
     oneshot
-
-service upgrade-nanohub /vendor/bin/nanoapp_cmd "download"
-    class core
-    oneshot


### PR DESCRIPTION
We have had 2 catfish have nanohub bricked so far. Not updating nanohub seems to have no side effects, so it's safer to leave that microcontroller alone until we figure out what's actually causing this issue.
Both of the issues happened on devices that were dual-booted, but we can't be sure that this won't happen on a full flash.