### PR TITLE
Disable Always-on-Display on catfish and narwhal by default.

### DIFF
--- a/meta-catfish/recipes-nemomobile/mce/mce/builtin-gconf.values
+++ b/meta-catfish/recipes-nemomobile/mce/mce/builtin-gconf.values
@@ -1,0 +1,2 @@
+/system/osso/dsm/display/display_brightness=5
+/system/osso/dsm/display/use_low_power_mode=false

--- a/meta-catfish/recipes-nemomobile/mce/mce_%.bbappend
+++ b/meta-catfish/recipes-nemomobile/mce/mce_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:catfish := "${THISDIR}/mce:"

--- a/meta-narwhal/recipes-nemomobile/mce/mce/builtin-gconf.values
+++ b/meta-narwhal/recipes-nemomobile/mce/mce/builtin-gconf.values
@@ -1,0 +1,2 @@
+/system/osso/dsm/display/display_brightness=5
+/system/osso/dsm/display/use_low_power_mode=false

--- a/meta-narwhal/recipes-nemomobile/mce/mce_%.bbappend
+++ b/meta-narwhal/recipes-nemomobile/mce/mce_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:narwhal := "${THISDIR}/mce:"


### PR DESCRIPTION
These watches have some other way to display the time when the screen is off (Additional LCD or physical hands).
Hence we don't need to have Always-on-Display enabled by default. This obviously improves the battery life since the SoC doesn't need to be awakened every minute.