### PR TITLE
narwhal: Fix micropone.

### DIFF
--- a/meta-narwhal/recipes-android/android/android/audio_policy.conf
+++ b/meta-narwhal/recipes-android/android/android/audio_policy.conf
@@ -1,0 +1,59 @@
+# Global configuration section: lists input and output devices always present on the device
+# as well as the output device selected by default.
+# Devices are designated by a string that corresponds to the enum in audio.h
+
+global_configuration {
+  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX
+}
+
+# audio hardware module section: contains descriptors for all audio hw modules present on the
+# device. Each hw module node is named after the corresponding hw module library base name.
+# For instance, "primary" corresponds to audio.primary.<device>.so.
+# The "primary" module is mandatory and must include at least one output with
+# AUDIO_OUTPUT_FLAG_PRIMARY flag.
+# Each module descriptor contains one or more output profile descriptors and zero or more
+# input profile descriptors. Each profile lists all the parameters supported by a given output
+# or input stream category.
+# The "channel_masks", "formats", "devices" and "flags" are specified using strings corresponding
+# to enums in audio.h and audio_policy.h. They are concatenated by use of "|" without space or "\n".
+
+audio_hw_modules {
+  primary {
+    inputs {
+      primary {
+        sampling_rates 8000|11025|16000|44100|48000
+        channel_masks AUDIO_CHANNEL_IN_MONO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_BUILTIN_MIC
+      }
+    }
+  }
+  a2dp {
+    outputs {
+      a2dp {
+        sampling_rates 44100
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_ALL_A2DP
+      }
+    }
+  }
+  r_submix {
+    outputs {
+      submix {
+        sampling_rates 48000
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_REMOTE_SUBMIX
+      }
+    }
+    inputs {
+      submix {
+        sampling_rates 48000
+        channel_masks AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_REMOTE_SUBMIX
+      }
+    }
+  }
+}

--- a/meta-narwhal/recipes-android/android/android_narwhal-n.bb
+++ b/meta-narwhal/recipes-android/android/android_narwhal-n.bb
@@ -3,7 +3,8 @@ inherit gettext
 SUMMARY = "Downloads the Snapdragon Wear 2100/3100 /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
 LICENSE = "CLOSED"
 
-SRC_URI = "https://dl.dropboxusercontent.com/s/8b9t2renrxbl4gq/hybris-o-msm8909.tar.gz;name=hybris"
+SRC_URI = "https://dl.dropboxusercontent.com/s/8b9t2renrxbl4gq/hybris-o-msm8909.tar.gz;name=hybris \
+    file://audio_policy.conf"
 SRC_URI[hybris.md5sum] = "edc1f8304b58af335a9c9ba8136bc1b8"
 SRC_URI[hybris.sha256sum] = "626bed275cfe2df2377e709498fc26d58e7883045cd13d4e2a6284220d1113b0"
 PV = "oreo"
@@ -19,6 +20,10 @@ PROVIDES += "virtual/android-system-image"
 PROVIDES += "virtual/android-headers"
 
 do_install() {
+    # The stock audio policy contains invalid entries that cause the droid module to fail.
+    install -d ${D}${sysconfdir}/pulse
+    install -m 0644 ${WORKDIR}/audio_policy.conf ${D}${sysconfdir}/pulse/
+
     install -d ${D}/usr/
     cp -r usr/* ${D}/usr/
 
@@ -35,6 +40,6 @@ do_package_qa() {
 }
 
 PACKAGES =+ "android-system android-headers"
-FILES:android-system = "/usr"
+FILES:android-system = "/usr ${sysconfdir}/pulse/"
 FILES:android-headers = "${libdir}/pkgconfig ${includedir}/android"
 EXCLUDE_FROM_SHLIBS = "1"

--- a/meta-narwhal/recipes-multimedia/pulseaudio/pulseaudio/default.pa
+++ b/meta-narwhal/recipes-multimedia/pulseaudio/pulseaudio/default.pa
@@ -1,0 +1,76 @@
+#!/usr/bin/pulseaudio -nF
+#
+# This file is part of PulseAudio.
+#
+# PulseAudio is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# PulseAudio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+
+### Load several protocols
+load-module module-native-protocol-unix
+
+load-module module-keepalive
+
+load-module module-dbus-protocol
+
+load-module module-meego-parameters cache=0 directory=/var/lib/nemo-pulseaudio-parameters use_voice=false
+load-module module-meego-mainvolume virtual_stream=true
+
+load-module module-stream-restore-nemo restore_device=no restore_volume=yes restore_muted=no route_table=/etc/pulse/x-maemo-route.table fallback_table=/etc/pulse/x-maemo-stream-restore.table use_voice=false
+
+load-module module-match table=/etc/pulse/x-maemo-match.table key=application.name
+
+.ifexists module-droid-card.so
+load-module module-droid-card source_channel_map=mono config=/etc/pulse/audio_policy.conf
+.endif
+
+### Automatically load driver modules for Bluetooth hardware
+.ifexists module-bluetooth-policy.so
+load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+load-module module-bluetooth-discover
+.endif
+
+#.ifexists module-bluez5-device.so
+#load-module module-bluez5-device
+#.endif
+
+.ifexists module-bluez5-discover.so
+load-module module-bluez5-discover
+.endif
+
+### Automatically restore the volume of streams and devices
+load-module module-device-restore
+
+### Automatically restore the default sink/source when changed by the user
+### during runtime
+### NOTE: This should be loaded as early as possible so that subsequent modules
+### that look up the default sink/source get the right value
+load-module module-default-device-restore
+
+### Should be after module-*-restore
+load-module module-switch-on-port-available
+
+### Automatically move streams to the default sink if the sink they are
+### connected to dies, similar for sources
+load-module module-rescue-streams
+
+### Make sure we always have a sink around, even if it is a null sink.
+load-module module-always-sink
+
+### Automatically suspend sinks/sources that become idle for too long
+load-module module-suspend-on-idle
+
+### Enable positioned event sounds
+load-module module-position-event-sounds

--- a/meta-narwhal/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-narwhal/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:narwhal := "${THISDIR}/pulseaudio:"


### PR DESCRIPTION
Add a custom audio policy configuration file that removes invalid entries such that the module-droid-card can successfully load it.
This fixes the microphone on `narwhal`.