### PR TITLE
skipjack: bluebinder: Downgrade bluebinder to fix Bluetooth.

### DIFF
--- a/meta-skipjack/recipes-core/bluebinder/bluebinder.bbappend
+++ b/meta-skipjack/recipes-core/bluebinder/bluebinder.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend:skipjack := "${THISDIR}/bluebinder:"
+
+LIC_FILES_CHKSUM:skipjack = "file://bluebinder.c;beginline=1;endline=29;md5=a5ec0cf2a3c5b266b4598f748dee0a39"
+
+SRCREV:skipjack = "632c3fb05010538b805a59ab23e6a4931989428f"

--- a/meta-skipjack/recipes-core/bluebinder/bluebinder/0001-service-fixes.patch
+++ b/meta-skipjack/recipes-core/bluebinder/bluebinder/0001-service-fixes.patch
@@ -1,0 +1,34 @@
+diff --git a/bluebinder.service b/bluebinder.service
+index a9f6c56..52eae10 100644
+--- a/bluebinder.service
++++ b/bluebinder.service
+@@ -1,26 +1,15 @@
+ [Unit]
+ Description=Simple proxy for using android binder based bluetooth through vhci.
+-After=droid-hal-init.service
++After=android-system.service
+ Before=bluetooth.service
+ 
+ [Service]
+ Type=notify
+-ExecStartPre=/usr/bin/droid/bluebinder_wait.sh
++ExecStartPre=/usr/sbin/bluebinder_wait.sh
+ ExecStart=/usr/sbin/bluebinder
+-ExecStartPost=/usr/bin/droid/bluebinder_post.sh
+ Restart=always
+ TimeoutStartSec=60
+-# Sandboxing
+-CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+-DeviceAllow=/dev/hwbinder rw
+-DeviceAllow=/dev/vhci rw
+-DevicePolicy=strict
+-NoNewPrivileges=yes
+-PrivateNetwork=true
+-PrivateTmp=yes
+-ProtectHome=yes
+-ProtectSystem=full
+ 
+ [Install]
+-WantedBy=graphical.target
++WantedBy=multi-user.target
+ 


### PR DESCRIPTION
Recent versions of Bluebinder rely on rfkill [^1].
Skipjack does not expose an /dev/rfkill device causing bluebinder to fail.

A probable more maintainable method would be to either:
- Provide two versions of `bluebinder`: `bluebinder-rfkill`, `bluebinder-no-rfkill`.
- Disable `rfkill` support at runtime by patching `bluebinder`.

This fixes https://github.com/AsteroidOS/asteroid/issues/216 and the bluetooth issue mentioned in https://github.com/AsteroidOS/asteroid/issues/212

[^1]: https://github.com/mer-hybris/bluebinder/pull/21