### PR TITLE
tetra: android-init: Initialize the PMU.

### DIFF
--- a/meta-tetra/recipes-android/android-init/android-init/init.rc
+++ b/meta-tetra/recipes-android/android-init/android-init/init.rc
@@ -3,6 +3,9 @@ on init
     mkdir /dev/graphics/
     symlink /dev/fb0 /dev/graphics/fb0
 
+# PMU init
+    write /sys/module/pwr_mgr/parameters/pm_late_init 1
+
 # Vibrator
     chown system root /sys/class/timed_output/vibrator/enable
 


### PR DESCRIPTION
Finally found a solution to the battery drain issue on `tetra`!
The solution is embarrassingly simple too!
Battery life has improved from barely making it up to 8 hours to an entire day of use with only ~25% drained.

I wasn't sure if it would work with AOD since we don't actually blank the display. But it looks like the PMU handles this perfectly.

I did notice that Bluetooth did become less reliable after this change. Removing the BLE only mode made it more reliable, so we could apply https://github.com/AsteroidOS/meta-smartwatch/commit/85e529c615f87f4cd8c923116b6d37e0059b2f12 here too.

This fixes https://github.com/AsteroidOS/meta-smartwatch/issues/35.