### PR TITLE
tetra: asteroid-launcher: Enable glyph workaround to fix font rendering issue.

### DIFF
--- a/meta-tetra/recipes-asteroid/asteroid-launcher/asteroid-launcher/default.conf
+++ b/meta-tetra/recipes-asteroid/asteroid-launcher/asteroid-launcher/default.conf
@@ -1,4 +1,5 @@
 EGL_PLATFORM=hwcomposer
 QT_QPA_PLATFORM=hwcomposer
 LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event1"
+QT_ENABLE_GLYPH_CACHE_WORKAROUND=true
 QT_IM_MODULE=qtvirtualkeyboard


### PR DESCRIPTION
`tetra` along with many other ports suffer from broken fonts due to a miscompilation in libc.so (from Android).
This results in broken fonts. Qt enables said workaround by default on Android builds but as we are building for Linux this isn't applied.
One can enable it at runtime via a environment variable.

Ref: https://bugreports.qt.io/browse/QTBUG-34984
