### PR TITLE
narwhal: Set timezone to zero to fix a synchronization issue.

### DIFF
--- a/meta-narwhal/recipes-android/android-init/android-init/init.rc
+++ b/meta-narwhal/recipes-android/android-init/android-init/init.rc
@@ -5,6 +5,7 @@ on init
     write /sys/devices/virtual/input/mxt_touch/check_fw "1"
     write /sys/devices/sop716/motor_move_all "45:135"
     write /sys/devices/sop716/watch_mode "1"
+    write /sys/devices/sop716/tz_minutes 0
 
     mkdir /dev/graphics/
     symlink /dev/fb0 /dev/graphics/fb0


### PR DESCRIPTION
AsteroidOS does not use time zones but WearOS does. This means that WearOS could store the current time including the timezone on physical hands module. Restoring the time on AsteroidOS from the physical hands would cause for an offset in hours as part of the timezone incompatibility. Setting it to zero fixes this until we have proper support for time zones in AsteroidOS.
