### PR TITLE
Specify python version in 0002-dtcat-Port-to-Python-3.patch

### DIFF
--- a/meta-minnow/recipes-kernel/linux/linux-minnow/0002-dtcat-Port-to-Python-3.patch
+++ b/meta-minnow/recipes-kernel/linux/linux-minnow/0002-dtcat-Port-to-Python-3.patch
@@ -1,16 +1,22 @@
-From d883c6d6a0d26aa9062a0b31d592003fc399d7a4 Mon Sep 17 00:00:00 2001
+From 45984376dee6b500502a313143995ccada342b05 Mon Sep 17 00:00:00 2001
 From: MagneFire <dgriet@gmail.com>
 Date: Sun, 8 May 2022 18:37:06 +0200
 Subject: [PATCH] dtcat: Port to Python 3.
 
 ---
- scripts/dtcat.py | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ scripts/dtcat.py | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/scripts/dtcat.py b/scripts/dtcat.py
-index add986245e2..060f9e17a56 100755
+index add986245e2a..784072d77b9a 100755
 --- a/scripts/dtcat.py
 +++ b/scripts/dtcat.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (C) 2013 Motorola, LLC.
+ #
 @@ -28,10 +28,10 @@ def padding(v):
  
  for f in sys.argv[1:]:
@@ -26,5 +32,5 @@ index add986245e2..060f9e17a56 100755
 +            sys.stdout.buffer.write(B'0')
  
 -- 
-2.35.1
+2.37.3
 


### PR DESCRIPTION
I've seen 3 approaches by distros concerning `python`
- It points to the newest python version
- It points to the latest (now EOL) version of python2
- It doesn't exist

The file is compatible with Python 3 and should therefore declare `python3` explicitly in the shebang.
With this minor patch, we don't depend on either `python2.7` being present or a `python-is-python3` package.