### PR TITLE
beluga: Enable NFC daemon and fix time after boot.

### DIFF
--- a/meta-beluga/conf/machine/beluga.conf
+++ b/meta-beluga/conf/machine/beluga.conf
@@ -14,4 +14,4 @@ PREFERRED_VERSION_android = "msm8909w+pie"
 PREFERRED_PROVIDER_virtual/kernel = "linux-beluga"
 PREFERRED_VERSION_linux = "4.9+pie"
 
-IMAGE_INSTALL += "sensorfw-hybris-binder-plugins udev-droid-system bluebinder asteroid-hrm asteroid-compass"
+IMAGE_INSTALL += "sensorfw-hybris-binder-plugins udev-droid-system bluebinder swclock-offset asteroid-hrm asteroid-compass"

--- a/meta-beluga/recipes-android/android-init/android-init/init.rc
+++ b/meta-beluga/recipes-android/android-init/android-init/init.rc
@@ -47,6 +47,9 @@ service gnss_service_becurx /vendor/bin/hw/android.hardware.gnss@1.0-service.cxd
     class hal
     oneshot
 
+service nfc_hal_service /vendor/bin/hw/android.hardware.nfc@1.1-service
+    class hal
+
 service deamonserver /system/bin/deamonserver
     class core
     oneshot

--- a/meta-beluga/recipes-nemomobile/nfcd/nfcd_git.bbappend
+++ b/meta-beluga/recipes-nemomobile/nfcd/nfcd_git.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN}:append:beluga = " nfcd-binder-plugin "


### PR DESCRIPTION
The time isn't saved to the RTC on `beluga` so we need to use `swclock-offset` to fix this (https://github.com/AsteroidOS/meta-asteroid/pull/121).

Additionally, add the binder runtime dependency to nfcd allowing us to use NFC tags on `beluga`.