### PR TITLE
tetra: android: Allow for empty main package

### DIFF
--- a/meta-tetra/recipes-android/android/android_tetra-mm.bb
+++ b/meta-tetra/recipes-android/android/android_tetra-mm.bb
@@ -38,6 +38,9 @@ do_install() {
 do_package_qa() {
 }
 
+# Allow empty main package since the -dev package depends on it
+ALLOW_EMPTY:${PN} = "1"
+
 PACKAGES =+ "android-system android-headers"
 FILES:android-system = "/system /vendor /usr"
 FILES:android-headers = "${libdir}/pkgconfig ${includedir}/android"


### PR DESCRIPTION
This is necessary, otherwise the -dev package cannot be installed in generated SDKs, since the -dev package depends on the main one.