### PR TITLE
wren: Correct preferred android version.

### DIFF
--- a/meta-wren/conf/machine/wren.conf
+++ b/meta-wren/conf/machine/wren.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
 require conf/machine/include/hybris-watch.inc
 
-PREFERRED_VERSION_android = "lollipop"
+PREFERRED_VERSION_android = "marshmallow"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-wren"
 PREFERRED_VERSION_linux = "3.10+marshmallow"


### PR DESCRIPTION
This fixes the following warnings:
```
WARNING: preferred version lollipop of android not available (for item android-system)
WARNING: versions of android available: marshmallow msm8909+pie msm8909w+pie
WARNING: preferred version lollipop of android not available (for item android)
WARNING: versions of android available: marshmallow msm8909+pie msm8909w+pie
WARNING: preferred version lollipop of android not available (for item android-dev)
WARNING: versions of android available: marshmallow msm8909+pie msm8909w+pie
WARNING: preferred version lollipop of android not available (for item virtual/android-headers)
WARNING: versions of android available: marshmallow msm8909+pie msm8909w+pie
```