### PR TITLE
ray: libhybris: Fix compilation.

### DIFF
--- a/meta-ray/recipes-core/libhybris/libhybris/0001-hybris-egl-Provide-eglCreatePlatformWindowSurface.patch
+++ b/meta-ray/recipes-core/libhybris/libhybris/0001-hybris-egl-Provide-eglCreatePlatformWindowSurface.patch
@@ -1,0 +1,51 @@
+From bfbf746e579e319ac0dc2b236d9aa48c163f7a57 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Mon, 13 Jun 2022 23:48:56 +0200
+Subject: [PATCH] hybris: egl: Provide eglCreatePlatformWindowSurface. Since
+ https://github.com/libhybris/libhybris/commit/a1bf776f4c06caba8078c7335deb766b3a77fdf1
+ the eglGetPlatformDisplay() function has been implemented. This function is
+ part of EGL 1.5.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some platforms rely on the existence of this function to detect if EGL 1.5 is supported [^1].
+However, libhybris does not implement all EGL 1.5 functions, this provides the implementation for the eglCreatePlatformWindowSurface() function to fix a compilation issue with Qt [^2].
+
+It's worth noting that the eglCreatePlatformWindowSurface() function and the eglCreateWindowSurface() function are not identical.
+Similar to https://github.com/libhybris/libhybris/commit/362efd97cd5b18f580c402d3fc14555f1ef6e31e we might need to implement additional type conversions at a later stage.
+
+[^1]: https://github.com/qt/qtwayland/blob/5.15.2/src/client/configure.json#L183
+[^2]: https://github.com/qt/qtwayland/blob/5.15.2/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp#L356
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ hybris/egl/egl.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/hybris/egl/egl.c b/hybris/egl/egl.c
+index 738eafd..9565ecf 100644
+--- a/hybris/egl/egl.c
++++ b/hybris/egl/egl.c
+@@ -315,6 +315,11 @@ EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
+ 	HYBRIS_TRACE_END("hybris-egl", "eglCreateWindowSurface", "");
+ 	return result;
+ }
++EGLSurface eglCreatePlatformWindowSurface(EGLDisplay dpy, EGLConfig config,
++		void *native_window, const EGLint *attrib_list)
++{
++	return eglCreateWindowSurface(dpy, config, (uintptr_t) native_window, attrib_list);
++}
+ 
+ static EGLSurface _my_eglCreatePlatformWindowSurfaceEXT(EGLDisplay dpy, EGLConfig config,
+ 		void *native_window, const EGLint *attrib_list)
+@@ -503,6 +508,7 @@ static struct FuncNamePair _eglHybrisOverrideFunctions[] = {
+ 	OVERRIDE_SAMENAME(eglGetPlatformDisplay),
+ 	OVERRIDE_SAMENAME(eglTerminate),
+ 	OVERRIDE_SAMENAME(eglCreateWindowSurface),
++	OVERRIDE_SAMENAME(eglCreatePlatformWindowSurface),
+ 	OVERRIDE_SAMENAME(eglDestroySurface),
+ 	OVERRIDE_SAMENAME(eglSwapInterval),
+ 	OVERRIDE_SAMENAME(eglCreateContext),
+-- 
+2.39.0
+

--- a/meta-ray/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-ray/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,7 +1,13 @@
+FILESEXTRAPATHS:prepend:ray := "${THISDIR}/libhybris:"
+
 SRCREV:ray = "9cadeefe224aa2387cc88c9d17a374df2f265ba8"
 
 SRC_URI:remove:ray = "file://0001-Add-EGL_OPENGL_ES3_BIT_KHR-define.patch;patchdir=.."
+SRC_URI:append:ray = " file://0001-hybris-egl-Provide-eglCreatePlatformWindowSurface.patch;patchdir=.."
+
+FILESEXTRAPATHS:prepend:firefish := "${THISDIR}/libhybris:"
 
 SRCREV:firefish = "9cadeefe224aa2387cc88c9d17a374df2f265ba8"
 
 SRC_URI:remove:firefish = "file://0001-Add-EGL_OPENGL_ES3_BIT_KHR-define.patch;patchdir=.."
+SRC_URI:append:firefish = " file://0001-hybris-egl-Provide-eglCreatePlatformWindowSurface.patch;patchdir=.."


### PR DESCRIPTION
Since  https://github.com/libhybris/libhybris/commit/a1bf776f4c06caba8078c7335deb766b3a77fdf1 the eglGetPlatformDisplay() function has been implemented. This function is part of EGL 1.5. Some platforms rely on the existence of this function to detect if EGL 1.5 is supported [^1]. However, libhybris does not implement all EGL 1.5 functions, this provides the implementation for the eglCreatePlatformWindowSurface() function to fix a compilation issue with Qt [^2].

It's worth noting that the eglCreatePlatformWindowSurface() function and the eglCreateWindowSurface() function are not identical. Similar to https://github.com/libhybris/libhybris/commit/362efd97cd5b18f580c402d3fc14555f1ef6e31e we might need to implement additional type conversions at a later stage.

[^1]: https://github.com/qt/qtwayland/blob/5.15.2/src/client/configure.json#L183
 [^2]: https://github.com/qt/qtwayland/blob/5.15.2/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp#L356

A PR for this fix is available upstream, but it has not been merged as of yet: https://github.com/libhybris/libhybris/pull/516