### PR TITLE
Move defaulttune from meta-asteroid hybris-watch.inc to machine-specific conf files.

### DIFF
--- a/meta-anthias/conf/machine/anthias.conf
+++ b/meta-anthias/conf/machine/anthias.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the ASUS Zenwatch
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 PREFERRED_VERSION_android = "lollipop"

--- a/meta-bass/conf/machine/bass.conf
+++ b/meta-bass/conf/machine/bass.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the LG Watch Urbane
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-beluga/conf/machine/beluga.conf
+++ b/meta-beluga/conf/machine/beluga.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the OPPO Watch
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_HAS_WLAN = "true"

--- a/meta-catfish/conf/machine/catfish.conf
+++ b/meta-catfish/conf/machine/catfish.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Ticwatch Pro
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-dory/conf/machine/dory.conf
+++ b/meta-dory/conf/machine/dory.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the LG G Watch
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_NEEDS_BURN_IN_PROTECTION = "false"

--- a/meta-lenok/conf/machine/lenok.conf
+++ b/meta-lenok/conf/machine/lenok.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the LG G Watch R
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-minnow/conf/machine/minnow.conf
+++ b/meta-minnow/conf/machine/minnow.conf
@@ -4,9 +4,8 @@
 #@DESCRIPTION: Machine configuration for the Moto 360
 
 require conf/machine/include/arm/armv7a/tune-cortexa8.inc
-require conf/machine/include/hybris-watch.inc
-
 DEFAULTTUNE = "armv7athf-neon"
+require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_FLAT_TIRE = "30"
 MACHINE_DISPLAY_BORDER_GESTURE_WIDTH = "0.2"

--- a/meta-mooneye/conf/machine/mooneye.conf
+++ b/meta-mooneye/conf/machine/mooneye.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Ticwatch E & S
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-mtk6580/conf/machine/harmony.conf
+++ b/meta-mtk6580/conf/machine/harmony.conf
@@ -10,6 +10,7 @@
 # - Diggro DI01, DI07
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-mtk6580/conf/machine/inharmony.conf
+++ b/meta-mtk6580/conf/machine/inharmony.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Diggro DI06
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-narwhal/conf/machine/narwhal.conf
+++ b/meta-narwhal/conf/machine/narwhal.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the LG Watch W7 (w315)
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-nemo/conf/machine/nemo.conf
+++ b/meta-nemo/conf/machine/nemo.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the LG Watch Urbane 2nd edition
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-pike/conf/machine/pike.conf
+++ b/meta-pike/conf/machine/pike.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Polar M600
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_HAS_WLAN = "true"

--- a/meta-ray/conf/machine/firefish.conf
+++ b/meta-ray/conf/machine/firefish.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Fossil Gen 4
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-ray/conf/machine/ray.conf
+++ b/meta-ray/conf/machine/ray.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Skagen Falster 2
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-sawfish/conf/machine/sawfish.conf
+++ b/meta-sawfish/conf/machine/sawfish.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Huawei Watch
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-skipjack/conf/machine/skipjack.conf
+++ b/meta-skipjack/conf/machine/skipjack.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Ticwatch C2+
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-smelt/conf/machine/smelt.conf
+++ b/meta-smelt/conf/machine/smelt.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Moto 360 2015
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-sparrow/conf/machine/sparrow.conf
+++ b/meta-sparrow/conf/machine/sparrow.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Asus ZenWatch 2
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_HAS_WLAN = "true"

--- a/meta-sprat/conf/machine/sprat.conf
+++ b/meta-sprat/conf/machine/sprat.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Samsung Gear Live
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 PREFERRED_VERSION_android = "lollipop"

--- a/meta-sturgeon/conf/machine/sturgeon.conf
+++ b/meta-sturgeon/conf/machine/sturgeon.conf
@@ -4,6 +4,7 @@
 #@DESCRIPTION: Machine configuration for the Huawei Watch
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-swift/conf/machine/swift.conf
+++ b/meta-swift/conf/machine/swift.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Asus Zenwatch 3
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_DISPLAY_ROUND = "true"

--- a/meta-tetra/conf/machine/tetra.conf
+++ b/meta-tetra/conf/machine/tetra.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Sony Smartwatch 3
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 MACHINE_NEEDS_BURN_IN_PROTECTION = "false"

--- a/meta-wren/conf/machine/wren.conf
+++ b/meta-wren/conf/machine/wren.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Machine configuration for the Asus ZenWatch 2
 
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+DEFAULTTUNE = "armv7vehf-neon"
 require conf/machine/include/hybris-watch.inc
 
 PREFERRED_VERSION_android = "marshmallow"


### PR DESCRIPTION
Since the processor tune is machine specific, it should be set in the same place where the architecture is defined.
this accompanies and should be merged before https://github.com/AsteroidOS/meta-asteroid/pull/132