### PR TITLE
Koi: psplash: add double buffering patch

### DIFF
--- a/meta-koi/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-koi/recipes-core/psplash/psplash_git.bbappend
@@ -1,3 +1,5 @@
+SRC_URI:append:koi = " file://0002-Disable-double-buffering.patch"
+
 do_install:append:koi() {
     install -d ${D}/usr/share/
     install -m 0755 ${WORKDIR}/psplash-img-400-220.gif ${D}/usr/share/psplash.gif


### PR DESCRIPTION
this reverts a change made in efc3b0c7, where the psplash double buffering patch was removed. The patch prevents a momentary display corruption as psplash stops and asteroid-launcher starts.
I failed to notice this during testing, as the corruption is very brief. After some far more rigorous testing, I can confirm that the display corruption reliably happens without the patch, and is definitely fixed by the patch. 