### PR TITLE
catfish: Install swclock-offset.

### DIFF
--- a/meta-catfish/conf/machine/catfish.conf
+++ b/meta-catfish/conf/machine/catfish.conf
@@ -17,4 +17,4 @@ PREFERRED_VERSION_android = "msm8909+pie"
 PREFERRED_PROVIDER_virtual/kernel = "linux-catfish"
 PREFERRED_VERSION_linux = "3.18+pie"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock lcd-tools udev-droid-system bluebinder asteroid-hrm asteroid-compass android-extras"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock lcd-tools udev-droid-system bluebinder swclock-offset asteroid-hrm asteroid-compass android-extras"


### PR DESCRIPTION
The time isn't saved to the RTC on `catfish` so we need to use `swclock-offset` to fix this.

This fixes #68.