### PR TITLE
koi: android: Do not try to install audio_policy.conf.

### DIFF
--- a/meta-koi/recipes-android/android/android_koi-o.bb
+++ b/meta-koi/recipes-android/android/android_koi-o.bb
@@ -19,10 +19,6 @@ PROVIDES += "virtual/android-system-image"
 PROVIDES += "virtual/android-headers"
 
 do_install() {
-    # The stock audio policy contains invalid entries that cause the droid module to fail.
-    install -d ${D}${sysconfdir}/pulse
-    install -m 0644 ${WORKDIR}/audio_policy.conf ${D}${sysconfdir}/pulse/
-
     install -d ${D}/usr/
     cp -r usr/* ${D}/usr/
 
@@ -41,6 +37,6 @@ do_package_qa() {
 }
 
 PACKAGES =+ "android-system android-headers"
-FILES:android-system = "/usr ${sysconfdir}/pulse/ /vendor"
+FILES:android-system = "/usr /vendor"
 FILES:android-headers = "${libdir}/pkgconfig ${includedir}/android"
 EXCLUDE_FROM_SHLIBS = "1"


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-smartwatch/commit/efc3b0c7ad9db17ae660dae513a03157294ecd08 removed the `audio_policy.conf` file as audio isn't working anyways. Yet, the recipe still tries to install this non-existing file.