### PR TITLE
narwhal: Add hands-timesync

### DIFF
--- a/meta-narwhal/conf/machine/narwhal.conf
+++ b/meta-narwhal/conf/machine/narwhal.conf
@@ -17,4 +17,4 @@ PREFERRED_VERSION_android = "oreo"
 PREFERRED_PROVIDER_virtual/kernel = "linux-narwhal"
 PREFERRED_VERSION_linux = "3.18+oreo"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock udev-droid-system bluebinder asteroid-compass"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock udev-droid-system bluebinder asteroid-compass hands-timesync"

--- a/meta-narwhal/recipes-android/android-init/android-init/init.rc
+++ b/meta-narwhal/recipes-android/android-init/android-init/init.rc
@@ -5,7 +5,6 @@ on init
     write /sys/devices/virtual/input/mxt_touch/check_fw "1"
     write /sys/devices/sop716/motor_move_all "45:135"
     write /sys/devices/sop716/watch_mode "1"
-    write /sys/devices/sop716/tz_minutes 0
 
     mkdir /dev/graphics/
     symlink /dev/fb0 /dev/graphics/fb0

--- a/meta-narwhal/recipes-core/hands-timesync/hands-timesync.bb
+++ b/meta-narwhal/recipes-core/hands-timesync/hands-timesync.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Utility to set correct time on LG Watch W7"
+HOMEPAGE = "https://github.com/AsteroidOS/narwhal-hands-timesync.git"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+SRC_URI = "git://github.com/asteroidos/narwhal-hands-timesync.git;branch=main;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r0"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+DEPENDS = "qtbase"
+inherit cmake_qt5
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install:append() {
+    install -d ${D}/etc/systemd/system/timers.target.wants/
+    ln -s /usr/lib/systemd/system/hands-timesync.timer ${D}/etc/systemd/system/timers.target.wants/hands-timesync.timer
+}
+
+FILES:${PN} += "/usr/lib/systemd/system/ /etc/systemd/"


### PR DESCRIPTION
despite this existing as an asteroid repo for over a year now, it's not actually been added as a recipe. I think this is a sign of anti-narwhal prejudice. 

This adds the recipe, and adds it to the narwhal image. 
it also removes the tz_minutes reset from init.rc: This was previously needed to make sure that the time would not change between reboots when it was being read back from the hands controller on bootup. This is no longer relevant, as asteroid now supports timezones (so the 0 reset would actually be harmful) and hands-timesync takes care of setting this value correctly.

It is worth checking how I've got the systemd units set up here. Unlike catfish and ayu, where the LCDs only display the time, the time set to the hands will be written to the main system after a reboot. For this reason, the time setting (as is convention on Linux) is restricted to root by making the systemd service and timer run as root, and keeping the permissions for the files /sys/devices/sop716/time and /sys/devices/sop716/tz_minutes locked down. 