### PR TITLE
sturgeon: sensorfw: Set default interval for the step counter.

### DIFF
--- a/meta-sturgeon/recipes-nemomobile/sensorfw/sensorfw/0001-HybrisStepCounterAdapter-Set-delay-to-normal-speed.patch
+++ b/meta-sturgeon/recipes-nemomobile/sensorfw/sensorfw/0001-HybrisStepCounterAdapter-Set-delay-to-normal-speed.patch
@@ -1,26 +1,22 @@
-From 45f0baec9a7db16db50a7a309486afeef4b20f61 Mon Sep 17 00:00:00 2001
+From 693017120d17ea51792749fcca3a915ccb34c076 Mon Sep 17 00:00:00 2001
 From: MagneFire <IDaNLContact@gmail.com>
 Date: Tue, 1 Dec 2020 20:24:52 +0100
 Subject: [PATCH] HybrisStepCounterAdapter: Set delay to normal speed. Fixes
  the stepcounter on at least sturgeon.
 
 ---
- adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp | 2 ++
- 1 file changed, 2 insertions(+)
+ adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp b/adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp
-index f51318e..7a8746d 100644
+index f77b290..6fea7e9 100644
 --- a/adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp
 +++ b/adaptors/hybrisstepcounteradaptor/hybrisstepcounteradaptor.cpp
-@@ -46,6 +46,8 @@ HybrisStepCounterAdaptor::HybrisStepCounterAdaptor(const QString& id) :
-     	sensordLogW() << "Path does not exists: " << powerStatePath;
-     	powerStatePath.clear();
-     }
-+    // Set default delay.
-+    setInterval(200, 0);
- }
+@@ -49,6 +49,7 @@ HybrisStepCounterAdaptor::~HybrisStepCounterAdaptor()
  
- HybrisStepCounterAdaptor::~HybrisStepCounterAdaptor()
--- 
-2.29.2
-
+ bool HybrisStepCounterAdaptor::startSensor()
+ {
++    setDefaultInterval(200);
+     if (!(HybrisAdaptor::startSensor()))
+         return false;
+     if (isRunning() && !powerStatePath.isEmpty())


### PR DESCRIPTION
The previous method no longer appears to work with recent versions of sensorfw. Instead of setting the interval a single time, set it as a default to prevent it from setting the interval to zero.

This commit is based on https://github.com/AsteroidOS/meta-smartwatch/commit/9460f010c90ced0a34a4b574651f551ede679737.