### PR TITLE
hoki: Prefer armv7+pie64.

### DIFF
--- a/meta-hoki/conf/machine/hoki.conf
+++ b/meta-hoki/conf/machine/hoki.conf
@@ -10,7 +10,7 @@ require conf/machine/include/hybris-watch.inc
 MACHINE_DISPLAY_ROUND = "true"
 
 PREFERRED_PROVIDER_virtual/android-system-image = "android"
-PREFERRED_VERSION_android = "msm8909w+pie"
+PREFERRED_VERSION_android = "armv7+pie64"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-hoki"
 PREFERRED_VERSION_linux = "4.14+pie"


### PR DESCRIPTION
This fixes an issue where the wrong android version could be used.
It was supposed to be fixed as part of: https://github.com/AsteroidOS/meta-smartwatch/pull/178