### PR TITLE
koi: set permissions for LCD in init.rc

### DIFF
--- a/meta-koi/recipes-android/android-init/android-init/init.rc
+++ b/meta-koi/recipes-android/android-init/android-init/init.rc
@@ -3,6 +3,9 @@ on init
     symlink /dev/fb0 /dev/graphics/fb0
     chown system root /sys/class/timed_output/vibrator/enable
 
+    chown system root /dev/MultiSensors_CD_01
+    chmod 666 /dev/MultiSensors_CD_01
+
     mkdir /data/
 
     class_start core


### PR DESCRIPTION
This is needed for ceres to be able to set time and change settings on the LCD. 