### PR TITLE
sawfish: linux-sawfish: Remove USB gadget function list.

### DIFF
--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish/00011-dts-sawshark-Remove-USB-gadget-function-list.patch
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish/00011-dts-sawshark-Remove-USB-gadget-function-list.patch
@@ -1,0 +1,30 @@
+From 533a411336f16ec60c61ced0b5ef11a58aabebb6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Wed, 2 Aug 2023 22:44:12 +0200
+Subject: [PATCH] dts: sawshark: Remove USB gadget function list.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead use the default list provided by the android gadget driver.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ arch/arm/boot/dts/apq8009w-sawshark/apq8009w-common.dtsi | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-common.dtsi b/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-common.dtsi
+index d68d98761aa..8d6aa1e63b9 100755
+--- a/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-common.dtsi
++++ b/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-common.dtsi
+@@ -32,7 +32,6 @@
+ 
+ 	android_usb@086000c8 {
+ 		compatible = "qcom,android-usb";
+-		qcom,supported-func = "ffs","diag","serial","mtp","rmnet";
+ 	};
+ };
+ 
+-- 
+2.41.0
+

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
@@ -21,6 +21,7 @@ SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-sawshar
     file://0008-Bluetooth-Fix-incorrect-gpio-definition-in-device-tr.patch \
     file://0009-cyttp5-Add-delay-for-wakeup-report.patch \
     file://0010-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
+    file://00011-dts-sawshark-Remove-USB-gadget-function-list.patch \
 "
 
 SRCREV = "66cf3d5be07a599af417695e4f22f304af667979"


### PR DESCRIPTION
Instead use the default list provided by the android gadget driver.

Essentially it adds rndis mode to the supported functions list, fixing SSH mode.