### PR TITLE
firefish/ray/skipjack/swift: Rename wifi-enabler to msm-wifi-enabler.

### DIFF
--- a/meta-ray/conf/machine/firefish.conf
+++ b/meta-ray/conf/machine/firefish.conf
@@ -16,4 +16,4 @@ PREFERRED_VERSION_android = "armv7+oreo"
 PREFERRED_PROVIDER_virtual/kernel = "linux-firefish"
 PREFERRED_VERSION_linux = "3.18+oreo"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock android-system-data udev-droid-system wifi-enabler bluebinder asteroid-hrm"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock android-system-data udev-droid-system msm-wifi-enabler bluebinder asteroid-hrm"

--- a/meta-ray/conf/machine/ray.conf
+++ b/meta-ray/conf/machine/ray.conf
@@ -16,4 +16,4 @@ PREFERRED_VERSION_android = "armv7+oreo"
 PREFERRED_PROVIDER_virtual/kernel = "linux-ray"
 PREFERRED_VERSION_linux = "3.18+oreo"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock android-system-data udev-droid-system wifi-enabler bluebinder asteroid-hrm"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock android-system-data udev-droid-system msm-wifi-enabler bluebinder asteroid-hrm"

--- a/meta-skipjack/conf/machine/skipjack.conf
+++ b/meta-skipjack/conf/machine/skipjack.conf
@@ -13,4 +13,4 @@ PREFERRED_VERSION_android = "armv7+oreo"
 PREFERRED_PROVIDER_virtual/kernel = "linux-skipjack"
 PREFERRED_VERSION_linux = "3.10+pie"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins android-tools android-system underclock android-system-data msm-fb-refresher bluebinder asteroid-hrm wifi-enabler udev-droid-system swclock-offset"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins android-tools android-system underclock android-system-data msm-fb-refresher bluebinder asteroid-hrm msm-wifi-enabler udev-droid-system swclock-offset"

--- a/meta-swift/conf/machine/swift.conf
+++ b/meta-swift/conf/machine/swift.conf
@@ -15,4 +15,4 @@ PREFERRED_VERSION_android = "marshmallow"
 PREFERRED_PROVIDER_virtual/kernel = "linux-swift"
 PREFERRED_VERSION_linux = "3.18+marshmallow"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins msm-fb-refresher wifi-enabler udev-droid-system"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins msm-fb-refresher msm-wifi-enabler udev-droid-system"


### PR DESCRIPTION
This depends on https://github.com/AsteroidOS/meta-asteroid/pull/177