### PR TITLE
Remove usage of BOOT_PARTITION.

### DIFF
--- a/meta-anthias/recipes-kernel/linux/linux-anthias_mm-dr1.bb
+++ b/meta-anthias/recipes-kernel/linux/linux-anthias_mm-dr1.bb
@@ -31,6 +31,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p11"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-bass/recipes-kernel/linux/linux-bass_lp-mr1.bb
+++ b/meta-bass/recipes-kernel/linux/linux-bass_lp-mr1.bb
@@ -27,6 +27,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-beluga/recipes-kernel/linux/linux-beluga_p.bb
+++ b/meta-beluga/recipes-kernel/linux/linux-beluga_p.bb
@@ -40,6 +40,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-catfish/recipes-kernel/linux/linux-catfish_p.bb
+++ b/meta-catfish/recipes-kernel/linux/linux-catfish_p.bb
@@ -29,6 +29,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
+++ b/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
@@ -28,6 +28,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-koi/recipes-kernel/linux/linux-koi_o.bb
+++ b/meta-koi/recipes-kernel/linux/linux-koi_o.bb
@@ -27,6 +27,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-lenok/recipes-kernel/linux/linux-lenok_mm-mr1.bb
+++ b/meta-lenok/recipes-kernel/linux/linux-lenok_mm-mr1.bb
@@ -29,6 +29,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
+++ b/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
@@ -31,6 +31,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p7"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
+++ b/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
@@ -38,6 +38,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-narwhal/recipes-kernel/linux/linux-narwhal_n.bb
+++ b/meta-narwhal/recipes-kernel/linux/linux-narwhal_n.bb
@@ -28,6 +28,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p35"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-nemo/recipes-kernel/linux/linux-nemo_lp-mr1.bb
+++ b/meta-nemo/recipes-kernel/linux/linux-nemo_lp-mr1.bb
@@ -24,6 +24,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-pike/recipes-kernel/linux/linux-pike_o.bb
+++ b/meta-pike/recipes-kernel/linux/linux-pike_o.bb
@@ -28,5 +28,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p7"
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-ray/recipes-kernel/linux/linux-firefish_o.bb
+++ b/meta-ray/recipes-kernel/linux/linux-firefish_o.bb
@@ -28,6 +28,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-ray/recipes-kernel/linux/linux-ray_n.bb
+++ b/meta-ray/recipes-kernel/linux/linux-ray_n.bb
@@ -28,6 +28,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
@@ -34,6 +34,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-skipjack/recipes-kernel/linux/linux-skipjack_o.bb
+++ b/meta-skipjack/recipes-kernel/linux/linux-skipjack_o.bb
@@ -32,6 +32,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p37"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-smelt/recipes-kernel/linux/linux-smelt_mm-mr1.bb
+++ b/meta-smelt/recipes-kernel/linux/linux-smelt_mm-mr1.bb
@@ -32,6 +32,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p24"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-sparrow/recipes-kernel/linux/linux-sparrow-mainline_6.0.bb
+++ b/meta-sparrow/recipes-kernel/linux/linux-sparrow-mainline_6.0.bb
@@ -19,8 +19,6 @@ PV = "${LINUX_VERSION}"
 S = "${WORKDIR}/git"
 B = "${S}"
 
-BOOT_PARTITION = "/dev/mmcblk0p11"
-
 # The boot.img needs to embed in its "kernel" section the concatenation of the zImage with the device tree blob
 KERNEL_OUTPUT = "${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}-dtb"
 do_deploy:append() {

--- a/meta-sparrow/recipes-kernel/linux/linux-sparrow_mm-mr1.bb
+++ b/meta-sparrow/recipes-kernel/linux/linux-sparrow_mm-mr1.bb
@@ -35,6 +35,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p11"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-sprat/recipes-kernel/linux/linux-sprat_mm-dr1.bb
+++ b/meta-sprat/recipes-kernel/linux/linux-sprat_mm-dr1.bb
@@ -24,6 +24,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p11"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
@@ -33,6 +33,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p15"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-swift/recipes-kernel/linux/linux-swift_mm-mr1.bb
+++ b/meta-swift/recipes-kernel/linux/linux-swift_mm-mr1.bb
@@ -27,6 +27,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/sda"
-
 inherit mkboot old-kernel-gcc-hdrs

--- a/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
+++ b/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
@@ -42,7 +42,6 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p29"
 MKBOOTIMG_ARGS = "--base 0x82000000"
 
 inherit mkbootimg old-kernel-gcc-hdrs

--- a/meta-wren/recipes-kernel/linux/linux-wren_mm-mr1.bb
+++ b/meta-wren/recipes-kernel/linux/linux-wren_mm-mr1.bb
@@ -42,6 +42,4 @@ do_install:append() {
     rm -rf ${D}/usr/src/usr/
 }
 
-BOOT_PARTITION = "/dev/mmcblk0p11"
-
 inherit mkboot old-kernel-gcc-hdrs


### PR DESCRIPTION
BOOT_PARTITION is not used in any recipe, remove it for all platforms.

This was identified by @FlorentRevest, thanks :smile: 