### PR TITLE
linux-audio-modules-beluga: fix mickledore build

### DIFF
--- a/meta-beluga/recipes-kernel/modules/linux-audio-modules-beluga/0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch
+++ b/meta-beluga/recipes-kernel/modules/linux-audio-modules-beluga/0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch
@@ -1,0 +1,25 @@
+From 7bcf29c0177330f64af7eeca32fefb0502ceeefe Mon Sep 17 00:00:00 2001
+From: Philip Russell <argosphil@murena.io>
+Date: Fri, 25 Aug 2023 12:26:10 +0000
+Subject: [PATCH] Avoid shell expansion in recursively-expanded variable
+
+GNU Make changed the behavior of that particular (avoidable and problematic)
+construct. Eagerly expanding the timestamp fixes the build on Mickledore.
+---
+ ipc/Kbuild | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/ipc/Kbuild b/ipc/Kbuild
+index b4a0f985..721526bd 100755
+--- a/ipc/Kbuild
++++ b/ipc/Kbuild
+@@ -224,4 +224,5 @@ obj-$(CONFIG_WCD_DSP_GLINK) += audio_wglink.o
+ audio_wglink-y := $(WDSP_GLINK)
+ 
+ # inject some build related information
+-CDEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+-- 
+2.41.0
+

--- a/meta-beluga/recipes-kernel/modules/linux-audio-modules-beluga_p.bb
+++ b/meta-beluga/recipes-kernel/modules/linux-audio-modules-beluga_p.bb
@@ -6,7 +6,9 @@ COMPATIBLE_MACHINE = "beluga"
 inherit module kernel-module-split
 
 SRC_URI = " git://android.googlesource.com/kernel/msm-extra;branch=android-msm-beluga-4.9-pie-wear-mr2;protocol=https \
-        file://0001-Make-warnings-non-fatal.patch"
+        file://0001-Make-warnings-non-fatal.patch \
+        file://0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch \
+"
 SRCREV = "9c56e30ea127e2c88188db5e2c1637e346ae75a3"
 LINUX_VERSION ?= "4.9"
 PV = "${LINUX_VERSION}+pie"


### PR DESCRIPTION
Avoid using a problematic GNU Make construct to allow building on mickledore.

I don't fully understand how `make` has changed and how it causes the problem, but there is code in `make` now that is reached in this specific situation.

Note that `asoc/Kbuild` includes `DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"`, which doesn't have any effect since it should be `CDEFINES`. Not modified to keep changes to a minimum.