### PR TITLE
mtk6580: android: Don't install include headers.

### DIFF
--- a/meta-mtk6580/recipes-android/android/android_harmony-lp.bb
+++ b/meta-mtk6580/recipes-android/android/android_harmony-lp.bb
@@ -19,10 +19,6 @@ do_install() {
     install -d ${D}/system/
     cp -r system/* ${D}/system/
 
-    install -d ${D}/usr/
-    rm -r usr/include/droidmedia/
-    cp -r usr/* ${D}/usr/
-
     install -d ${D}${includedir}/android
     cp -r include/* ${D}${includedir}/android/
 
@@ -42,6 +38,6 @@ do_package_qa() {
 }
 
 PACKAGES =+ "android-system android-headers"
-FILES:android-system = "/system /vendor /usr /etc/firmware"
+FILES:android-system = "/system /vendor /etc/firmware"
 FILES:android-headers = "${libdir}/pkgconfig ${includedir}/android"
 EXCLUDE_FROM_SHLIBS = "1"


### PR DESCRIPTION
The `include` directory in the tarball only contains the droidmedia headers.
3fccd3f605f4746e2abd123b6caa0083fcadcbe6 removed these headers from the extracted tarball, then it copies this to the destination directory.
However this introduces an issue when `do_install` is called multiple times since it can't delete the headers anymore (they don't exist).