### PR TITLE
triggerfish: Prefer armv7+pie64.

### DIFF
--- a/meta-triggerfish/conf/machine/triggerfish.conf
+++ b/meta-triggerfish/conf/machine/triggerfish.conf
@@ -12,7 +12,7 @@ MACHINE_HAS_WLAN = "true"
 MACHINE_HAS_SPEAKER = "true"
 
 PREFERRED_PROVIDER_virtual/android-system-image = "android"
-PREFERRED_VERSION_android = "msm8909w+pie"
+PREFERRED_VERSION_android = "armv7+pie64"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-triggerfish"
 PREFERRED_VERSION_linux = "3.18+pie"


### PR DESCRIPTION
Recipe names were changed in https://github.com/AsteroidOS/meta-asteroid/commit/66075d2bbd2fad9bc61cf88b8b054c906a4fc8a7.
This change wasn't reflected for `triggerfish` resulting in it building any `android` package as part of the system, possibly randomly breaking functionality.