### PR TITLE
Update dory and sturgeon

### DIFF
--- a/meta-dory/recipes-kernel/linux/linux-dory/0008-random-introduce-getrandom-2-system-call.patch
+++ b/meta-dory/recipes-kernel/linux/linux-dory/0008-random-introduce-getrandom-2-system-call.patch
@@ -1,0 +1,333 @@
+From 49ed3617068dc8db73f68994ef4fa56193f8c4bf Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Thu, 17 Jul 2014 04:13:05 -0400
+Subject: [PATCH 1/2] random: introduce getrandom(2) system call
+
+The getrandom(2) system call was requested by the LibreSSL Portable
+developers.  It is analoguous to the getentropy(2) system call in
+OpenBSD.
+
+The rationale of this system call is to provide resiliance against
+file descriptor exhaustion attacks, where the attacker consumes all
+available file descriptors, forcing the use of the fallback code where
+/dev/[u]random is not available.  Since the fallback code is often not
+well-tested, it is better to eliminate this potential failure mode
+entirely.
+
+The other feature provided by this new system call is the ability to
+request randomness from the /dev/urandom entropy pool, but to block
+until at least 128 bits of entropy has been accumulated in the
+/dev/urandom entropy pool.  Historically, the emphasis in the
+/dev/urandom development has been to ensure that urandom pool is
+initialized as quickly as possible after system boot, and preferably
+before the init scripts start execution.
+
+This is because changing /dev/urandom reads to block represents an
+interface change that could potentially break userspace which is not
+acceptable.  In practice, on most x86 desktop and server systems, in
+general the entropy pool can be initialized before it is needed (and
+in modern kernels, we will printk a warning message if not).  However,
+on an embedded system, this may not be the case.  And so with this new
+interface, we can provide the functionality of blocking until the
+urandom pool has been initialized.  Any userspace program which uses
+this new functionality must take care to assure that if it is used
+during the boot process, that it will not cause the init scripts or
+other portions of the system startup to hang indefinitely.
+
+SYNOPSIS
+	#include <linux/random.h>
+
+	int getrandom(void *buf, size_t buflen, unsigned int flags);
+
+DESCRIPTION
+	The system call getrandom() fills the buffer pointed to by buf
+	with up to buflen random bytes which can be used to seed user
+	space random number generators (i.e., DRBG's) or for other
+	cryptographic uses.  It should not be used for Monte Carlo
+	simulations or other programs/algorithms which are doing
+	probabilistic sampling.
+
+	If the GRND_RANDOM flags bit is set, then draw from the
+	/dev/random pool instead of the /dev/urandom pool.  The
+	/dev/random pool is limited based on the entropy that can be
+	obtained from environmental noise, so if there is insufficient
+	entropy, the requested number of bytes may not be returned.
+	If there is no entropy available at all, getrandom(2) will
+	either block, or return an error with errno set to EAGAIN if
+	the GRND_NONBLOCK bit is set in flags.
+
+	If the GRND_RANDOM bit is not set, then the /dev/urandom pool
+	will be used.  Unlike using read(2) to fetch data from
+	/dev/urandom, if the urandom pool has not been sufficiently
+	initialized, getrandom(2) will block (or return -1 with the
+	errno set to EAGAIN if the GRND_NONBLOCK bit is set in flags).
+
+	The getentropy(2) system call in OpenBSD can be emulated using
+	the following function:
+
+            int getentropy(void *buf, size_t buflen)
+            {
+                    int     ret;
+
+                    if (buflen > 256)
+                            goto failure;
+                    ret = getrandom(buf, buflen, 0);
+                    if (ret < 0)
+                            return ret;
+                    if (ret == buflen)
+                            return 0;
+            failure:
+                    errno = EIO;
+                    return -1;
+            }
+
+RETURN VALUE
+       On success, the number of bytes that was filled in the buf is
+       returned.  This may not be all the bytes requested by the
+       caller via buflen if insufficient entropy was present in the
+       /dev/random pool, or if the system call was interrupted by a
+       signal.
+
+       On error, -1 is returned, and errno is set appropriately.
+
+ERRORS
+	EINVAL		An invalid flag was passed to getrandom(2)
+
+	EFAULT		buf is outside the accessible address space.
+
+	EAGAIN		The requested entropy was not available, and
+			getentropy(2) would have blocked if the
+			GRND_NONBLOCK flag was not set.
+
+	EINTR		While blocked waiting for entropy, the call was
+			interrupted by a signal handler; see the description
+			of how interrupted read(2) calls on "slow" devices
+			are handled with and without the SA_RESTART flag
+			in the signal(7) man page.
+
+NOTES
+	For small requests (buflen <= 256) getrandom(2) will not
+	return EINTR when reading from the urandom pool once the
+	entropy pool has been initialized, and it will return all of
+	the bytes that have been requested.  This is the recommended
+	way to use getrandom(2), and is designed for compatibility
+	with OpenBSD's getentropy() system call.
+
+	However, if you are using GRND_RANDOM, then getrandom(2) may
+	block until the entropy accounting determines that sufficient
+	environmental noise has been gathered such that getrandom(2)
+	will be operating as a NRBG instead of a DRBG for those people
+	who are working in the NIST SP 800-90 regime.  Since it may
+	block for a long time, these guarantees do *not* apply.  The
+	user may want to interrupt a hanging process using a signal,
+	so blocking until all of the requested bytes are returned
+	would be unfriendly.
+
+	For this reason, the user of getrandom(2) MUST always check
+	the return value, in case it returns some error, or if fewer
+	bytes than requested was returned.  In the case of
+	!GRND_RANDOM and small request, the latter should never
+	happen, but the careful userspace code (and all crypto code
+	should be careful) should check for this anyway!
+
+	Finally, unless you are doing long-term key generation (and
+	perhaps not even then), you probably shouldn't be using
+	GRND_RANDOM.  The cryptographic algorithms used for
+	/dev/urandom are quite conservative, and so should be
+	sufficient for all purposes.  The disadvantage of GRND_RANDOM
+	is that it can block, and the increased complexity required to
+	deal with partially fulfilled getrandom(2) requests.
+
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+Reviewed-by: Zach Brown <zab@zabbo.net>
+---
+ arch/x86/syscalls/syscall_32.tbl  |  1 +
+ arch/x86/syscalls/syscall_64.tbl  |  2 +-
+ drivers/char/random.c             | 42 ++++++++++++++++++++++++++++---
+ include/linux/syscalls.h          |  2 ++
+ include/uapi/asm-generic/unistd.h |  4 ++-
+ include/uapi/linux/random.h       | 10 ++++++++
+ 6 files changed, 55 insertions(+), 6 deletions(-)
+
+diff --git a/arch/x86/syscalls/syscall_32.tbl b/arch/x86/syscalls/syscall_32.tbl
+index 531bb1421584..fc853fb1079b 100644
+--- a/arch/x86/syscalls/syscall_32.tbl
++++ b/arch/x86/syscalls/syscall_32.tbl
+@@ -361,3 +361,4 @@
+ 352	i386	sched_getattr		sys_sched_getattr
+ # 353	i386	renameat2		sys_renameat2
+ 354	i386	seccomp			sys_seccomp
++355	i386	getrandom		sys_getrandom
+diff --git a/arch/x86/syscalls/syscall_64.tbl b/arch/x86/syscalls/syscall_64.tbl
+index 80d126d61999..51fd56e463cc 100644
+--- a/arch/x86/syscalls/syscall_64.tbl
++++ b/arch/x86/syscalls/syscall_64.tbl
+@@ -324,7 +324,7 @@
+ 315	common	sched_getattr		sys_sched_getattr
+ # 316	common	renameat2		sys_renameat2
+ 317	common	seccomp			sys_seccomp
+-
++318	common	getrandom		sys_getrandom
+ #
+ # x32-specific system call numbers start at 512 to avoid cache impact
+ # for native 64-bit operation.
+diff --git a/drivers/char/random.c b/drivers/char/random.c
+index 9cc496177c11..bead8cc318ec 100644
+--- a/drivers/char/random.c
++++ b/drivers/char/random.c
+@@ -256,6 +256,8 @@
+ #include <linux/ptrace.h>
+ #include <linux/kmemcheck.h>
+ #include <linux/irq.h>
++#include <linux/syscalls.h>
++#include <linux/completion.h>
+
+ #include <asm/processor.h>
+ #include <asm/uaccess.h>
+@@ -394,6 +396,7 @@ static struct poolinfo {
+  */
+ static DECLARE_WAIT_QUEUE_HEAD(random_read_wait);
+ static DECLARE_WAIT_QUEUE_HEAD(random_write_wait);
++static DECLARE_WAIT_QUEUE_HEAD(urandom_init_wait);
+ static struct fasync_struct *fasync;
+
+ static bool debug;
+@@ -603,8 +606,10 @@ retry:
+
+	if (!r->initialized && nbits > 0) {
+		r->entropy_total += nbits;
+-		if (r->entropy_total > 128)
++		if (r->entropy_total > 128) {
+			r->initialized = 1;
++			wake_up_interruptible(&urandom_init_wait);
++		}
+	}
+
+	trace_credit_entropy_bits(r->name, nbits, entropy_count,
+@@ -1012,13 +1017,14 @@ static ssize_t extract_entropy_user(struct entropy_store *r, void __user *buf,
+ {
+	ssize_t ret = 0, i;
+	__u8 tmp[EXTRACT_SIZE];
++	int large_request = (nbytes > 256);
+
+	trace_extract_entropy_user(r->name, nbytes, r->entropy_count, _RET_IP_);
+	xfer_secondary_pool(r, nbytes);
+	nbytes = account(r, nbytes, 0, 0);
+
+	while (nbytes) {
+-		if (need_resched()) {
++		if (large_request && need_resched()) {
+			if (signal_pending(current)) {
+				if (ret == 0)
+					ret = -ERESTARTSYS;
+@@ -1152,7 +1158,7 @@ void rand_initialize_disk(struct gendisk *disk)
+ #endif
+
+ static ssize_t
+-random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
++_random_read(int nonblock, char __user *buf, size_t nbytes)
+ {
+	ssize_t n, retval = 0, count = 0;
+
+@@ -1177,7 +1183,7 @@ random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+			  n*8, (nbytes-n)*8);
+
+		if (n == 0) {
+-			if (file->f_flags & O_NONBLOCK) {
++			if (nonblock) {
+				retval = -EAGAIN;
+				break;
+			}
+@@ -1208,12 +1214,40 @@ random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+	return (count ? count : retval);
+ }
+
++static ssize_t
++random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
++{
++	return _random_read(file->f_flags & O_NONBLOCK, buf, nbytes);
++}
+ static ssize_t
+ urandom_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+ {
+	return extract_entropy_user(&nonblocking_pool, buf, nbytes);
+ }
+
++SYSCALL_DEFINE3(getrandom, char __user *, buf, size_t, count,
++		unsigned int, flags)
++{
++	if (flags & ~(GRND_NONBLOCK|GRND_RANDOM))
++		return -EINVAL;
++
++	if (count > INT_MAX)
++		count = INT_MAX;
++
++	if (flags & GRND_RANDOM)
++		return _random_read(flags & GRND_NONBLOCK, buf, count);
++
++	if (unlikely(nonblocking_pool.initialized == 0)) {
++		if (flags & GRND_NONBLOCK)
++			return -EAGAIN;
++		wait_event_interruptible(urandom_init_wait,
++					 nonblocking_pool.initialized);
++		if (signal_pending(current))
++			return -ERESTARTSYS;
++	}
++	return urandom_read(NULL, buf, count, NULL);
++}
++
+ static unsigned int
+ random_poll(struct file *file, poll_table * wait)
+ {
+diff --git a/include/linux/syscalls.h b/include/linux/syscalls.h
+index 5946b623b04a..5b280184e57e 100644
+--- a/include/linux/syscalls.h
++++ b/include/linux/syscalls.h
+@@ -856,4 +856,6 @@ asmlinkage long sys_kcmp(pid_t pid1, pid_t pid2, int type,
+ asmlinkage long sys_finit_module(int fd, const char __user *uargs, int flags);
+ asmlinkage long sys_seccomp(unsigned int op, unsigned int flags,
+			    const char __user *uargs);
++asmlinkage long sys_getrandom(char __user *buf, size_t count,
++			      unsigned int flags);
+ #endif
+diff --git a/include/uapi/asm-generic/unistd.h b/include/uapi/asm-generic/unistd.h
+index 7e14d705a30f..1bb905296859 100644
+--- a/include/uapi/asm-generic/unistd.h
++++ b/include/uapi/asm-generic/unistd.h
+@@ -701,9 +701,11 @@ __SYSCALL(__NR_sched_getattr, sys_sched_getattr)
+ __SYSCALL(__NR_renameat2, sys_ni_syscall)
+ #define __NR_seccomp 277
+ __SYSCALL(__NR_seccomp, sys_seccomp)
++#define __NR_getrandom 278
++__SYSCALL(__NR_getrandom, sys_getrandom)
+
+ #undef __NR_syscalls
+-#define __NR_syscalls 278
++#define __NR_syscalls 279
+
+ /*
+  * All syscalls below here should go away really,
+diff --git a/include/uapi/linux/random.h b/include/uapi/linux/random.h
+index 7471b5b3b8ba..905598bad01c 100644
+--- a/include/uapi/linux/random.h
++++ b/include/uapi/linux/random.h
+@@ -44,6 +44,16 @@ struct rnd_state {
+	__u32 s1, s2, s3;
+ };
+
++
++/*
++ * Flags for getrandom(2)
++ *
++ * GRND_NONBLOCK	Don't block and return EAGAIN instead
++ * GRND_RANDOM		Use the /dev/random pool instead of /dev/urandom
++ */
++#define GRND_NONBLOCK	0x0001
++#define GRND_RANDOM	0x0002
++
+ /* Exported functions */
+
+
+--
+2.42.0
+

--- a/meta-dory/recipes-kernel/linux/linux-dory/0009-ARM-wire-up-getrandom-syscall.patch
+++ b/meta-dory/recipes-kernel/linux/linux-dory/0009-ARM-wire-up-getrandom-syscall.patch
@@ -1,0 +1,54 @@
+From 1f478ae79159853c5dab2923cad5ba7decc5a876 Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@arm.linux.org.uk>
+Date: Fri, 8 Aug 2014 10:56:34 +0100
+Subject: [PATCH 2/2] ARM: wire up getrandom syscall
+
+Add the new getrandom syscall for ARM.
+
+Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
+---
+ arch/arm/include/asm/unistd.h      | 2 +-
+ arch/arm/include/uapi/asm/unistd.h | 1 +
+ arch/arm/kernel/calls.S            | 1 +
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/include/asm/unistd.h b/arch/arm/include/asm/unistd.h
+index 43876245fc57..2ed963aa6b3b 100644
+--- a/arch/arm/include/asm/unistd.h
++++ b/arch/arm/include/asm/unistd.h
+@@ -15,7 +15,7 @@
+
+ #include <uapi/asm/unistd.h>
+
+-#define __NR_syscalls  (384)
++#define __NR_syscalls  (388)
+ #define __ARM_NR_cmpxchg		(__ARM_NR_BASE+0x00fff0)
+
+ #define __ARCH_WANT_STAT64
+diff --git a/arch/arm/include/uapi/asm/unistd.h b/arch/arm/include/uapi/asm/unistd.h
+index a1e6667045c3..dc85809fce7f 100644
+--- a/arch/arm/include/uapi/asm/unistd.h
++++ b/arch/arm/include/uapi/asm/unistd.h
+@@ -411,6 +411,7 @@
+ /* Backport seccomp, stub renameat2 call */
+ #define __NR_renameat2			(__NR_SYSCALL_BASE+382)
+ #define __NR_seccomp			(__NR_SYSCALL_BASE+383)
++#define __NR_getrandom			(__NR_SYSCALL_BASE+384)
+
+ /*
+  * This may need to be greater than __NR_last_syscall+1 in order to
+diff --git a/arch/arm/kernel/calls.S b/arch/arm/kernel/calls.S
+index e4df5b6c2101..7b866d483b05 100644
+--- a/arch/arm/kernel/calls.S
++++ b/arch/arm/kernel/calls.S
+@@ -393,6 +393,7 @@
+		CALL(sys_sched_getattr)
+		CALL(sys_ni_syscall)
+		CALL(sys_seccomp)
++		CALL(sys_getrandom)
+ #ifndef syscalls_counted
+ .equ syscalls_padding, ((NR_syscalls + 3) & ~3) - NR_syscalls
+ #define syscalls_counted
+--
+2.42.0
+

--- a/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
+++ b/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
@@ -17,7 +17,10 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-dory-3.1
     file://0004-bluesleep-Use-kernel-s-HCI-events-instead-of-proc-bl.patch \
     file://0005-msm_pwm_vibrator-Convert-timed_output-APIs-to-ff_mem.patch \
     file://0006-synaptics_i2c_rmi4-Adds-a-wakelock-when-the-screen-i.patch \
-    file://0007-ARM-uaccess-remove-put_user-code-duplication.patch"
+    file://0007-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0008-random-introduce-getrandom-2-system-call.patch \
+    file://0009-ARM-wire-up-getrandom-syscall.patch \
+"
 SRCREV = "6924014484d3406e3d2da384efc20e40e8a5ae80"
 LINUX_VERSION ?= "3.10"
 PV = "${LINUX_VERSION}+marshmallow"

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0011-random-introduce-getrandom-2-system-call.patch
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0011-random-introduce-getrandom-2-system-call.patch
@@ -1,0 +1,333 @@
+From 49ed3617068dc8db73f68994ef4fa56193f8c4bf Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Thu, 17 Jul 2014 04:13:05 -0400
+Subject: [PATCH 1/2] random: introduce getrandom(2) system call
+
+The getrandom(2) system call was requested by the LibreSSL Portable
+developers.  It is analoguous to the getentropy(2) system call in
+OpenBSD.
+
+The rationale of this system call is to provide resiliance against
+file descriptor exhaustion attacks, where the attacker consumes all
+available file descriptors, forcing the use of the fallback code where
+/dev/[u]random is not available.  Since the fallback code is often not
+well-tested, it is better to eliminate this potential failure mode
+entirely.
+
+The other feature provided by this new system call is the ability to
+request randomness from the /dev/urandom entropy pool, but to block
+until at least 128 bits of entropy has been accumulated in the
+/dev/urandom entropy pool.  Historically, the emphasis in the
+/dev/urandom development has been to ensure that urandom pool is
+initialized as quickly as possible after system boot, and preferably
+before the init scripts start execution.
+
+This is because changing /dev/urandom reads to block represents an
+interface change that could potentially break userspace which is not
+acceptable.  In practice, on most x86 desktop and server systems, in
+general the entropy pool can be initialized before it is needed (and
+in modern kernels, we will printk a warning message if not).  However,
+on an embedded system, this may not be the case.  And so with this new
+interface, we can provide the functionality of blocking until the
+urandom pool has been initialized.  Any userspace program which uses
+this new functionality must take care to assure that if it is used
+during the boot process, that it will not cause the init scripts or
+other portions of the system startup to hang indefinitely.
+
+SYNOPSIS
+	#include <linux/random.h>
+
+	int getrandom(void *buf, size_t buflen, unsigned int flags);
+
+DESCRIPTION
+	The system call getrandom() fills the buffer pointed to by buf
+	with up to buflen random bytes which can be used to seed user
+	space random number generators (i.e., DRBG's) or for other
+	cryptographic uses.  It should not be used for Monte Carlo
+	simulations or other programs/algorithms which are doing
+	probabilistic sampling.
+
+	If the GRND_RANDOM flags bit is set, then draw from the
+	/dev/random pool instead of the /dev/urandom pool.  The
+	/dev/random pool is limited based on the entropy that can be
+	obtained from environmental noise, so if there is insufficient
+	entropy, the requested number of bytes may not be returned.
+	If there is no entropy available at all, getrandom(2) will
+	either block, or return an error with errno set to EAGAIN if
+	the GRND_NONBLOCK bit is set in flags.
+
+	If the GRND_RANDOM bit is not set, then the /dev/urandom pool
+	will be used.  Unlike using read(2) to fetch data from
+	/dev/urandom, if the urandom pool has not been sufficiently
+	initialized, getrandom(2) will block (or return -1 with the
+	errno set to EAGAIN if the GRND_NONBLOCK bit is set in flags).
+
+	The getentropy(2) system call in OpenBSD can be emulated using
+	the following function:
+
+            int getentropy(void *buf, size_t buflen)
+            {
+                    int     ret;
+
+                    if (buflen > 256)
+                            goto failure;
+                    ret = getrandom(buf, buflen, 0);
+                    if (ret < 0)
+                            return ret;
+                    if (ret == buflen)
+                            return 0;
+            failure:
+                    errno = EIO;
+                    return -1;
+            }
+
+RETURN VALUE
+       On success, the number of bytes that was filled in the buf is
+       returned.  This may not be all the bytes requested by the
+       caller via buflen if insufficient entropy was present in the
+       /dev/random pool, or if the system call was interrupted by a
+       signal.
+
+       On error, -1 is returned, and errno is set appropriately.
+
+ERRORS
+	EINVAL		An invalid flag was passed to getrandom(2)
+
+	EFAULT		buf is outside the accessible address space.
+
+	EAGAIN		The requested entropy was not available, and
+			getentropy(2) would have blocked if the
+			GRND_NONBLOCK flag was not set.
+
+	EINTR		While blocked waiting for entropy, the call was
+			interrupted by a signal handler; see the description
+			of how interrupted read(2) calls on "slow" devices
+			are handled with and without the SA_RESTART flag
+			in the signal(7) man page.
+
+NOTES
+	For small requests (buflen <= 256) getrandom(2) will not
+	return EINTR when reading from the urandom pool once the
+	entropy pool has been initialized, and it will return all of
+	the bytes that have been requested.  This is the recommended
+	way to use getrandom(2), and is designed for compatibility
+	with OpenBSD's getentropy() system call.
+
+	However, if you are using GRND_RANDOM, then getrandom(2) may
+	block until the entropy accounting determines that sufficient
+	environmental noise has been gathered such that getrandom(2)
+	will be operating as a NRBG instead of a DRBG for those people
+	who are working in the NIST SP 800-90 regime.  Since it may
+	block for a long time, these guarantees do *not* apply.  The
+	user may want to interrupt a hanging process using a signal,
+	so blocking until all of the requested bytes are returned
+	would be unfriendly.
+
+	For this reason, the user of getrandom(2) MUST always check
+	the return value, in case it returns some error, or if fewer
+	bytes than requested was returned.  In the case of
+	!GRND_RANDOM and small request, the latter should never
+	happen, but the careful userspace code (and all crypto code
+	should be careful) should check for this anyway!
+
+	Finally, unless you are doing long-term key generation (and
+	perhaps not even then), you probably shouldn't be using
+	GRND_RANDOM.  The cryptographic algorithms used for
+	/dev/urandom are quite conservative, and so should be
+	sufficient for all purposes.  The disadvantage of GRND_RANDOM
+	is that it can block, and the increased complexity required to
+	deal with partially fulfilled getrandom(2) requests.
+
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+Reviewed-by: Zach Brown <zab@zabbo.net>
+---
+ arch/x86/syscalls/syscall_32.tbl  |  1 +
+ arch/x86/syscalls/syscall_64.tbl  |  2 +-
+ drivers/char/random.c             | 42 ++++++++++++++++++++++++++++---
+ include/linux/syscalls.h          |  2 ++
+ include/uapi/asm-generic/unistd.h |  4 ++-
+ include/uapi/linux/random.h       | 10 ++++++++
+ 6 files changed, 55 insertions(+), 6 deletions(-)
+
+diff --git a/arch/x86/syscalls/syscall_32.tbl b/arch/x86/syscalls/syscall_32.tbl
+index 531bb1421584..fc853fb1079b 100644
+--- a/arch/x86/syscalls/syscall_32.tbl
++++ b/arch/x86/syscalls/syscall_32.tbl
+@@ -361,3 +361,4 @@
+ 352	i386	sched_getattr		sys_sched_getattr
+ # 353	i386	renameat2		sys_renameat2
+ 354	i386	seccomp			sys_seccomp
++355	i386	getrandom		sys_getrandom
+diff --git a/arch/x86/syscalls/syscall_64.tbl b/arch/x86/syscalls/syscall_64.tbl
+index 80d126d61999..51fd56e463cc 100644
+--- a/arch/x86/syscalls/syscall_64.tbl
++++ b/arch/x86/syscalls/syscall_64.tbl
+@@ -324,7 +324,7 @@
+ 315	common	sched_getattr		sys_sched_getattr
+ # 316	common	renameat2		sys_renameat2
+ 317	common	seccomp			sys_seccomp
+-
++318	common	getrandom		sys_getrandom
+ #
+ # x32-specific system call numbers start at 512 to avoid cache impact
+ # for native 64-bit operation.
+diff --git a/drivers/char/random.c b/drivers/char/random.c
+index 9cc496177c11..bead8cc318ec 100644
+--- a/drivers/char/random.c
++++ b/drivers/char/random.c
+@@ -256,6 +256,8 @@
+ #include <linux/ptrace.h>
+ #include <linux/kmemcheck.h>
+ #include <linux/irq.h>
++#include <linux/syscalls.h>
++#include <linux/completion.h>
+
+ #include <asm/processor.h>
+ #include <asm/uaccess.h>
+@@ -394,6 +396,7 @@ static struct poolinfo {
+  */
+ static DECLARE_WAIT_QUEUE_HEAD(random_read_wait);
+ static DECLARE_WAIT_QUEUE_HEAD(random_write_wait);
++static DECLARE_WAIT_QUEUE_HEAD(urandom_init_wait);
+ static struct fasync_struct *fasync;
+
+ static bool debug;
+@@ -603,8 +606,10 @@ retry:
+
+	if (!r->initialized && nbits > 0) {
+		r->entropy_total += nbits;
+-		if (r->entropy_total > 128)
++		if (r->entropy_total > 128) {
+			r->initialized = 1;
++			wake_up_interruptible(&urandom_init_wait);
++		}
+	}
+
+	trace_credit_entropy_bits(r->name, nbits, entropy_count,
+@@ -1012,13 +1017,14 @@ static ssize_t extract_entropy_user(struct entropy_store *r, void __user *buf,
+ {
+	ssize_t ret = 0, i;
+	__u8 tmp[EXTRACT_SIZE];
++	int large_request = (nbytes > 256);
+
+	trace_extract_entropy_user(r->name, nbytes, r->entropy_count, _RET_IP_);
+	xfer_secondary_pool(r, nbytes);
+	nbytes = account(r, nbytes, 0, 0);
+
+	while (nbytes) {
+-		if (need_resched()) {
++		if (large_request && need_resched()) {
+			if (signal_pending(current)) {
+				if (ret == 0)
+					ret = -ERESTARTSYS;
+@@ -1152,7 +1158,7 @@ void rand_initialize_disk(struct gendisk *disk)
+ #endif
+
+ static ssize_t
+-random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
++_random_read(int nonblock, char __user *buf, size_t nbytes)
+ {
+	ssize_t n, retval = 0, count = 0;
+
+@@ -1177,7 +1183,7 @@ random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+			  n*8, (nbytes-n)*8);
+
+		if (n == 0) {
+-			if (file->f_flags & O_NONBLOCK) {
++			if (nonblock) {
+				retval = -EAGAIN;
+				break;
+			}
+@@ -1208,12 +1214,40 @@ random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+	return (count ? count : retval);
+ }
+
++static ssize_t
++random_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
++{
++	return _random_read(file->f_flags & O_NONBLOCK, buf, nbytes);
++}
+ static ssize_t
+ urandom_read(struct file *file, char __user *buf, size_t nbytes, loff_t *ppos)
+ {
+	return extract_entropy_user(&nonblocking_pool, buf, nbytes);
+ }
+
++SYSCALL_DEFINE3(getrandom, char __user *, buf, size_t, count,
++		unsigned int, flags)
++{
++	if (flags & ~(GRND_NONBLOCK|GRND_RANDOM))
++		return -EINVAL;
++
++	if (count > INT_MAX)
++		count = INT_MAX;
++
++	if (flags & GRND_RANDOM)
++		return _random_read(flags & GRND_NONBLOCK, buf, count);
++
++	if (unlikely(nonblocking_pool.initialized == 0)) {
++		if (flags & GRND_NONBLOCK)
++			return -EAGAIN;
++		wait_event_interruptible(urandom_init_wait,
++					 nonblocking_pool.initialized);
++		if (signal_pending(current))
++			return -ERESTARTSYS;
++	}
++	return urandom_read(NULL, buf, count, NULL);
++}
++
+ static unsigned int
+ random_poll(struct file *file, poll_table * wait)
+ {
+diff --git a/include/linux/syscalls.h b/include/linux/syscalls.h
+index 5946b623b04a..5b280184e57e 100644
+--- a/include/linux/syscalls.h
++++ b/include/linux/syscalls.h
+@@ -856,4 +856,6 @@ asmlinkage long sys_kcmp(pid_t pid1, pid_t pid2, int type,
+ asmlinkage long sys_finit_module(int fd, const char __user *uargs, int flags);
+ asmlinkage long sys_seccomp(unsigned int op, unsigned int flags,
+			    const char __user *uargs);
++asmlinkage long sys_getrandom(char __user *buf, size_t count,
++			      unsigned int flags);
+ #endif
+diff --git a/include/uapi/asm-generic/unistd.h b/include/uapi/asm-generic/unistd.h
+index 7e14d705a30f..1bb905296859 100644
+--- a/include/uapi/asm-generic/unistd.h
++++ b/include/uapi/asm-generic/unistd.h
+@@ -701,9 +701,11 @@ __SYSCALL(__NR_sched_getattr, sys_sched_getattr)
+ __SYSCALL(__NR_renameat2, sys_ni_syscall)
+ #define __NR_seccomp 277
+ __SYSCALL(__NR_seccomp, sys_seccomp)
++#define __NR_getrandom 278
++__SYSCALL(__NR_getrandom, sys_getrandom)
+
+ #undef __NR_syscalls
+-#define __NR_syscalls 278
++#define __NR_syscalls 279
+
+ /*
+  * All syscalls below here should go away really,
+diff --git a/include/uapi/linux/random.h b/include/uapi/linux/random.h
+index 7471b5b3b8ba..905598bad01c 100644
+--- a/include/uapi/linux/random.h
++++ b/include/uapi/linux/random.h
+@@ -44,6 +44,16 @@ struct rnd_state {
+	__u32 s1, s2, s3;
+ };
+
++
++/*
++ * Flags for getrandom(2)
++ *
++ * GRND_NONBLOCK	Don't block and return EAGAIN instead
++ * GRND_RANDOM		Use the /dev/random pool instead of /dev/urandom
++ */
++#define GRND_NONBLOCK	0x0001
++#define GRND_RANDOM	0x0002
++
+ /* Exported functions */
+
+
+--
+2.42.0
+

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0012-ARM-wire-up-getrandom-syscall.patch
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0012-ARM-wire-up-getrandom-syscall.patch
@@ -1,0 +1,54 @@
+From 1f478ae79159853c5dab2923cad5ba7decc5a876 Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@arm.linux.org.uk>
+Date: Fri, 8 Aug 2014 10:56:34 +0100
+Subject: [PATCH 2/2] ARM: wire up getrandom syscall
+
+Add the new getrandom syscall for ARM.
+
+Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
+---
+ arch/arm/include/asm/unistd.h      | 2 +-
+ arch/arm/include/uapi/asm/unistd.h | 1 +
+ arch/arm/kernel/calls.S            | 1 +
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/include/asm/unistd.h b/arch/arm/include/asm/unistd.h
+index 43876245fc57..2ed963aa6b3b 100644
+--- a/arch/arm/include/asm/unistd.h
++++ b/arch/arm/include/asm/unistd.h
+@@ -15,7 +15,7 @@
+
+ #include <uapi/asm/unistd.h>
+
+-#define __NR_syscalls  (384)
++#define __NR_syscalls  (388)
+ #define __ARM_NR_cmpxchg		(__ARM_NR_BASE+0x00fff0)
+
+ #define __ARCH_WANT_STAT64
+diff --git a/arch/arm/include/uapi/asm/unistd.h b/arch/arm/include/uapi/asm/unistd.h
+index a1e6667045c3..dc85809fce7f 100644
+--- a/arch/arm/include/uapi/asm/unistd.h
++++ b/arch/arm/include/uapi/asm/unistd.h
+@@ -411,6 +411,7 @@
+ /* Backport seccomp, stub renameat2 call */
+ #define __NR_renameat2			(__NR_SYSCALL_BASE+382)
+ #define __NR_seccomp			(__NR_SYSCALL_BASE+383)
++#define __NR_getrandom			(__NR_SYSCALL_BASE+384)
+
+ /*
+  * This may need to be greater than __NR_last_syscall+1 in order to
+diff --git a/arch/arm/kernel/calls.S b/arch/arm/kernel/calls.S
+index e4df5b6c2101..7b866d483b05 100644
+--- a/arch/arm/kernel/calls.S
++++ b/arch/arm/kernel/calls.S
+@@ -393,6 +393,7 @@
+		CALL(sys_sched_getattr)
+		CALL(sys_ni_syscall)
+		CALL(sys_seccomp)
++		CALL(sys_getrandom)
+ #ifndef syscalls_counted
+ .equ syscalls_padding, ((NR_syscalls + 3) & ~3) - NR_syscalls
+ #define syscalls_counted
+--
+2.42.0
+

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
@@ -21,6 +21,8 @@ SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-sturgeo
     file://0008-tap-to-wake-fix.patch \
     file://0009-bluesleep-Use-kernel-s-HCI-events-instead-of-proc-bl.patch \
     file://0010-synaptics_i2c_rmi4-Adds-a-wakelock-when-the-screen-i.patch \
+    file://0011-random-introduce-getrandom-2-system-call.patch \
+    file://0012-ARM-wire-up-getrandom-syscall.patch \
 "
 
 SRCREV = "97abcf5b24684a46530ffc8a4748dd7ae6c2e65a"


### PR DESCRIPTION
This is based on @MagneFire's excellent work in backporting random.c changes in the kernel to kernel version 3.10.  Note that this only addresses `dory` and `sturgeon` because those are the only two kernl version 3.10 watches I have available to test.  

This relates to https://github.com/AsteroidOS/asteroid/issues/245 to allow us to move from `kirkstone` to `mickledore`.