### PR TITLE
hoki: Fix sensors

### DIFF
--- a/meta-hoki/conf/machine/hoki.conf
+++ b/meta-hoki/conf/machine/hoki.conf
@@ -15,4 +15,4 @@ PREFERRED_VERSION_android = "armv7+pie64"
 PREFERRED_PROVIDER_virtual/kernel = "linux-hoki"
 PREFERRED_VERSION_linux = "4.14+pie"
 
-IMAGE_INSTALL += "android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki qrtr"
+IMAGE_INSTALL += "sensorfw-hybris-binder-plugins android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki qrtr"

--- a/meta-hoki/conf/machine/hoki.conf
+++ b/meta-hoki/conf/machine/hoki.conf
@@ -15,4 +15,4 @@ PREFERRED_VERSION_android = "armv7+pie64"
 PREFERRED_PROVIDER_virtual/kernel = "linux-hoki"
 PREFERRED_VERSION_linux = "4.14+pie"
 
-IMAGE_INSTALL += "android-system-data udev-droid-system bluebinder swclock-offset underclock"
+IMAGE_INSTALL += "android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki"

--- a/meta-hoki/conf/machine/hoki.conf
+++ b/meta-hoki/conf/machine/hoki.conf
@@ -15,4 +15,4 @@ PREFERRED_VERSION_android = "armv7+pie64"
 PREFERRED_PROVIDER_virtual/kernel = "linux-hoki"
 PREFERRED_VERSION_linux = "4.14+pie"
 
-IMAGE_INSTALL += "sensorfw-hybris-binder-plugins android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki qrtr"
+IMAGE_INSTALL += "sensorfw-hybris-binder-plugins android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki qrtr asteroid-hrm asteroid-compass"

--- a/meta-hoki/conf/machine/hoki.conf
+++ b/meta-hoki/conf/machine/hoki.conf
@@ -15,4 +15,4 @@ PREFERRED_VERSION_android = "armv7+pie64"
 PREFERRED_PROVIDER_virtual/kernel = "linux-hoki"
 PREFERRED_VERSION_linux = "4.14+pie"
 
-IMAGE_INSTALL += "android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki"
+IMAGE_INSTALL += "android-system-data udev-droid-system bluebinder swclock-offset underclock linux-audio-modules-hoki qrtr"

--- a/meta-hoki/recipes-android/android-init/android-init/init.rc
+++ b/meta-hoki/recipes-android/android-init/android-init/init.rc
@@ -5,6 +5,12 @@ on init
     write /sys/bus/msm_subsys/devices/subsys3/restart_level "RELATED"
     write /sys/bus/msm_subsys/devices/subsys4/restart_level "RELATED"
 
+    exec -- /sbin/modprobe -a audio_apr audio_adsp_loader audio_q6_notifier audio_q6 audio_usf audio_native audio_pinctrl_wcd audio_swr audio_platform audio_swr_ctrl audio_mbhc audio_stub audio_machine
+
+    write /sys/kernel/boot_adsp/boot 1
+    write /sys/kernel/boot_cdsp/boot 1
+    write /sys/kernel/boot_slpi/boot 1
+
     # Required to fix some symbolic links in wcnss firmware files.
     mkdir /mnt/vendor/
     symlink /persist /mnt/vendor/persist

--- a/meta-hoki/recipes-android/android-init/android-init/init.rc
+++ b/meta-hoki/recipes-android/android-init/android-init/init.rc
@@ -63,8 +63,28 @@ service vendor.bluetooth-1-0 /vendor/bin/hw/android.hardware.bluetooth@1.0-servi
 service vendor.per_mgr /vendor/bin/pm-service
     class core
 
+on property:init.svc.vendor.per_mgr=running
+    start vendor.per_proxy
+
+service vendor.per_proxy /system/vendor/bin/pm-proxy
+    class core
+    disabled
+
 service sidekickgraphics-hal-1-2 /vendor/bin/hw/vendor.qti.hardware.sidekickgraphics@1.2-service
     class hal
+
+service vendor.sensors-hal-1-0 /vendor/bin/hw/android.hardware.sensors@1.0-service
+    class hal
+    oneshot
+
+service vendor.sensors.qti /vendor/bin/sensors.qti
+    class core
+
+service adsprpcd /system/vendor/bin/adsprpcd
+    class core
+
+service adsprpcd_sensorspd /system/vendor/bin/adsprpcd sensorspd
+    class core
 
 on property:sys.boot_completed=1
     exec -- /vendor/bin/init.rsb.sh

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0001-Remove-export-from-Kbuild-files.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0001-Remove-export-from-Kbuild-files.patch
@@ -1,0 +1,801 @@
+From 2b9ef7dd384fccd17d04d6a8bc62e0534516ff2e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Tue, 9 Jan 2024 22:13:31 +0100
+Subject: [PATCH] Remove export from Kbuild files.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes possible host contamination.
+
+Co-authored-by: Philip Russell <argosphil@murena.io>
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ asoc/Kbuild                   | 28 ++++++++++++++--------------
+ asoc/codecs/Kbuild            | 26 +++++++++++++-------------
+ asoc/codecs/aqt1000/Kbuild    |  6 +++---
+ asoc/codecs/bolero/Kbuild     |  6 +++---
+ asoc/codecs/csra66x0/Kbuild   |  2 +-
+ asoc/codecs/ep92/Kbuild       |  2 +-
+ asoc/codecs/msm_sdw/Kbuild    |  8 ++++----
+ asoc/codecs/sdm660_cdc/Kbuild |  8 ++++----
+ asoc/codecs/wcd934x/Kbuild    | 16 ++++++++--------
+ asoc/codecs/wcd9360/Kbuild    |  4 ++--
+ asoc/codecs/wcd937x/Kbuild    |  4 ++--
+ dsp/Kbuild                    | 28 ++++++++++++++--------------
+ dsp/codecs/Kbuild             | 22 +++++++++++-----------
+ ipc/Kbuild                    | 28 ++++++++++++++--------------
+ soc/Kbuild                    | 28 ++++++++++++++--------------
+ 15 files changed, 108 insertions(+), 108 deletions(-)
+
+diff --git a/asoc/Kbuild b/asoc/Kbuild
+index 9c519c6..32d747d 100644
+--- a/asoc/Kbuild
++++ b/asoc/Kbuild
+@@ -16,75 +16,75 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		ifdef CONFIG_SND_SOC_SA6155
+ 			include $(AUDIO_ROOT)/config/sa6155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa6155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm6150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/Kbuild b/asoc/codecs/Kbuild
+index 827f5b7..a0255dd 100644
+--- a/asoc/codecs/Kbuild
++++ b/asoc/codecs/Kbuild
+@@ -16,69 +16,69 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		ifdef CONFIG_SND_SOC_SA6155
+ 			include $(AUDIO_ROOT)/config/sa6155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa6155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm6150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/aqt1000/Kbuild b/asoc/codecs/aqt1000/Kbuild
+index ccf9ff0..69b530f 100644
+--- a/asoc/codecs/aqt1000/Kbuild
++++ b/asoc/codecs/aqt1000/Kbuild
+@@ -19,19 +19,19 @@ ifeq ($(KERNEL_BUILD), 0)
+ 
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/bolero/Kbuild b/asoc/codecs/bolero/Kbuild
+index 8e3a26d..ebd8ccf 100644
+--- a/asoc/codecs/bolero/Kbuild
++++ b/asoc/codecs/bolero/Kbuild
+@@ -18,17 +18,17 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		include $(AUDIO_ROOT)/config/sm6150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/csra66x0/Kbuild b/asoc/codecs/csra66x0/Kbuild
+index ef2f14e..190ee69 100644
+--- a/asoc/codecs/csra66x0/Kbuild
++++ b/asoc/codecs/csra66x0/Kbuild
+@@ -17,7 +17,7 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/ep92/Kbuild b/asoc/codecs/ep92/Kbuild
+index dd6afe2..46e7850 100644
+--- a/asoc/codecs/ep92/Kbuild
++++ b/asoc/codecs/ep92/Kbuild
+@@ -18,7 +18,7 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/msm_sdw/Kbuild b/asoc/codecs/msm_sdw/Kbuild
+index 2d238e4..40a3485 100644
+--- a/asoc/codecs/msm_sdw/Kbuild
++++ b/asoc/codecs/msm_sdw/Kbuild
+@@ -17,22 +17,22 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/sdm660_cdc/Kbuild b/asoc/codecs/sdm660_cdc/Kbuild
+index 9f9bba9..d58cfd9 100644
+--- a/asoc/codecs/sdm660_cdc/Kbuild
++++ b/asoc/codecs/sdm660_cdc/Kbuild
+@@ -17,22 +17,22 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/wcd934x/Kbuild b/asoc/codecs/wcd934x/Kbuild
+index 95747a8..e4bbddb 100644
+--- a/asoc/codecs/wcd934x/Kbuild
++++ b/asoc/codecs/wcd934x/Kbuild
+@@ -18,42 +18,42 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		include $(AUDIO_ROOT)/config/sm6150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/wcd9360/Kbuild b/asoc/codecs/wcd9360/Kbuild
+index e997916..9b9a411 100644
+--- a/asoc/codecs/wcd9360/Kbuild
++++ b/asoc/codecs/wcd9360/Kbuild
+@@ -18,13 +18,13 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/wcd937x/Kbuild b/asoc/codecs/wcd937x/Kbuild
+index 9648542..f99cda0 100644
+--- a/asoc/codecs/wcd937x/Kbuild
++++ b/asoc/codecs/wcd937x/Kbuild
+@@ -18,12 +18,12 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		include $(AUDIO_ROOT)/config/sm6150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ endif
+diff --git a/dsp/Kbuild b/dsp/Kbuild
+index dec3631..950bba5 100644
+--- a/dsp/Kbuild
++++ b/dsp/Kbuild
+@@ -16,75 +16,75 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		ifdef CONFIG_SND_SOC_SA6155
+ 			include $(AUDIO_ROOT)/config/sa6155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa6155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm6150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/dsp/codecs/Kbuild b/dsp/codecs/Kbuild
+index a0337e7..32366f2 100644
+--- a/dsp/codecs/Kbuild
++++ b/dsp/codecs/Kbuild
+@@ -16,58 +16,58 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		include $(AUDIO_ROOT)/config/sm6150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		include $(AUDIO_ROOT)/config/sm8150auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/ipc/Kbuild b/ipc/Kbuild
+index 85f7da3..436fbaa 100644
+--- a/ipc/Kbuild
++++ b/ipc/Kbuild
+@@ -17,75 +17,75 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+         ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		ifdef CONFIG_SND_SOC_SA6155
+ 			include $(AUDIO_ROOT)/config/sa6155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa6155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm6150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 		endif
+         endif
+         ifeq ($(CONFIG_ARCH_TRINKET), y)
+                 include $(AUDIO_ROOT)/config/trinketauto.conf
+-                export
++
+                 INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+         endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/soc/Kbuild b/soc/Kbuild
+index 87faacd..aef236f 100644
+--- a/soc/Kbuild
++++ b/soc/Kbuild
+@@ -16,75 +16,75 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm670auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm670autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM8150), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SM6150), y)
+ 		ifdef CONFIG_SND_SOC_SA6155
+ 			include $(AUDIO_ROOT)/config/sa6155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa6155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm6150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm6150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_TRINKET), y)
+ 		include $(AUDIO_ROOT)/config/trinketauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/trinketautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+ 		ifdef CONFIG_SND_SOC_SA8155
+ 			include $(AUDIO_ROOT)/config/sa8155auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sa8155autoconf.h
+ 		else
+ 			include $(AUDIO_ROOT)/config/sm8150auto.conf
+-			export
++
+ 			INCS    +=  -include $(AUDIO_ROOT)/config/sm8150autoconf.h
+ 		endif
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_QCS405), y)
+ 		include $(AUDIO_ROOT)/config/qcs405auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/qcs405autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPRAIRIE), y)
+ 		include $(AUDIO_ROOT)/config/sdxprairieauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxprairieautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_QTI_GVM), y)
+ 		include $(AUDIO_ROOT)/config/gvmauto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/gvmautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM429W), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch
@@ -1,0 +1,196 @@
+From ad6fbf187ffa4f25004e5fcb4afe2cfc3e0c8b2e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Tue, 9 Jan 2024 22:29:27 +0100
+Subject: [PATCH] Avoid shell expansion in recursively-expanded variable.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GNU Make changed the behavior of that particular (avoidable and problematic) construct.
+Eagerly expanding the timestamp fixes the build on Mickledore.
+
+Co-authored-by: Philip Russell <argosphil@murena.io>
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ asoc/Kbuild                   | 3 ++-
+ asoc/codecs/Kbuild            | 3 ++-
+ asoc/codecs/aqt1000/Kbuild    | 3 ++-
+ asoc/codecs/bolero/Kbuild     | 3 ++-
+ asoc/codecs/csra66x0/Kbuild   | 3 ++-
+ asoc/codecs/ep92/Kbuild       | 3 ++-
+ asoc/codecs/msm_sdw/Kbuild    | 3 ++-
+ asoc/codecs/sdm660_cdc/Kbuild | 3 ++-
+ asoc/codecs/wcd934x/Kbuild    | 3 ++-
+ asoc/codecs/wcd9360/Kbuild    | 3 ++-
+ asoc/codecs/wcd937x/Kbuild    | 3 ++-
+ dsp/Kbuild                    | 3 ++-
+ dsp/codecs/Kbuild             | 3 ++-
+ ipc/Kbuild                    | 3 ++-
+ soc/Kbuild                    | 3 ++-
+ 15 files changed, 30 insertions(+), 15 deletions(-)
+
+diff --git a/asoc/Kbuild b/asoc/Kbuild
+index 32d747d..9beb346 100644
+--- a/asoc/Kbuild
++++ b/asoc/Kbuild
+@@ -306,4 +306,5 @@ obj-$(CONFIG_SND_SOC_MACHINE_SDXPRAIRIE) += machine_dlkm.o
+ machine_dlkm-y := $(MACHINE_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/Kbuild b/asoc/codecs/Kbuild
+index a0255dd..5bd1d98 100644
+--- a/asoc/codecs/Kbuild
++++ b/asoc/codecs/Kbuild
+@@ -274,4 +274,5 @@ obj-$(CONFIG_SND_SOC_MSM_HDMI_CODEC_RX) += hdmi_dlkm.o
+ hdmi_dlkm-y := $(HDMICODEC_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/aqt1000/Kbuild b/asoc/codecs/aqt1000/Kbuild
+index 69b530f..7748545 100644
+--- a/asoc/codecs/aqt1000/Kbuild
++++ b/asoc/codecs/aqt1000/Kbuild
+@@ -126,4 +126,5 @@ obj-$(CONFIG_SND_SOC_AQT1000) += aqt1000_cdc_dlkm.o
+ aqt1000_cdc_dlkm-y := $(AQT1000_CDC_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/bolero/Kbuild b/asoc/codecs/bolero/Kbuild
+index ebd8ccf..b6e3a85 100644
+--- a/asoc/codecs/bolero/Kbuild
++++ b/asoc/codecs/bolero/Kbuild
+@@ -150,4 +150,5 @@ obj-$(CONFIG_RX_MACRO) += rx_macro_dlkm.o
+ rx_macro_dlkm-y := $(RX_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/csra66x0/Kbuild b/asoc/codecs/csra66x0/Kbuild
+index 190ee69..633073a 100644
+--- a/asoc/codecs/csra66x0/Kbuild
++++ b/asoc/codecs/csra66x0/Kbuild
+@@ -111,4 +111,5 @@ obj-$(CONFIG_SND_SOC_CSRA66X0) += csra66x0_dlkm.o
+ csra66x0_dlkm-y := $(CSRA66X0_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/ep92/Kbuild b/asoc/codecs/ep92/Kbuild
+index 46e7850..2899975 100644
+--- a/asoc/codecs/ep92/Kbuild
++++ b/asoc/codecs/ep92/Kbuild
+@@ -112,4 +112,5 @@ obj-$(CONFIG_SND_SOC_EP92) += ep92_dlkm.o
+ ep92_dlkm-y := $(EP92_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/msm_sdw/Kbuild b/asoc/codecs/msm_sdw/Kbuild
+index 40a3485..c5fcdc2 100644
+--- a/asoc/codecs/msm_sdw/Kbuild
++++ b/asoc/codecs/msm_sdw/Kbuild
+@@ -126,4 +126,5 @@ obj-$(CONFIG_SND_SOC_MSM_SDW) += msm_sdw_dlkm.o
+ msm_sdw_dlkm-y := $(MSM_SDW_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/sdm660_cdc/Kbuild b/asoc/codecs/sdm660_cdc/Kbuild
+index d58cfd9..6dfc6b8 100644
+--- a/asoc/codecs/sdm660_cdc/Kbuild
++++ b/asoc/codecs/sdm660_cdc/Kbuild
+@@ -141,4 +141,5 @@ obj-$(CONFIG_SND_SOC_DIGITAL_CDC_LEGACY) += audio_digital_cdc.o
+ audio_digital_cdc-y := $(DIGITAL_CDC_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/wcd934x/Kbuild b/asoc/codecs/wcd934x/Kbuild
+index e4bbddb..a5423f2 100644
+--- a/asoc/codecs/wcd934x/Kbuild
++++ b/asoc/codecs/wcd934x/Kbuild
+@@ -147,4 +147,5 @@ obj-$(CONFIG_SND_SOC_WCD934X) += wcd934x_dlkm.o
+ wcd934x_dlkm-y := $(WCD934X_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/wcd9360/Kbuild b/asoc/codecs/wcd9360/Kbuild
+index 9b9a411..eaa1851 100644
+--- a/asoc/codecs/wcd9360/Kbuild
++++ b/asoc/codecs/wcd9360/Kbuild
+@@ -116,4 +116,5 @@ obj-$(CONFIG_SND_SOC_WCD9360) += wcd9360_dlkm.o
+ wcd9360_dlkm-y := $(WCD9360_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/asoc/codecs/wcd937x/Kbuild b/asoc/codecs/wcd937x/Kbuild
+index f99cda0..31ed43f 100644
+--- a/asoc/codecs/wcd937x/Kbuild
++++ b/asoc/codecs/wcd937x/Kbuild
+@@ -124,4 +124,5 @@ obj-$(CONFIG_SND_SOC_WCD937X_SLAVE) += wcd937x_slave_dlkm.o
+ wcd937x_slave_dlkm-y := $(WCD937X_SLAVE_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/dsp/Kbuild b/dsp/Kbuild
+index 950bba5..650c7be 100644
+--- a/dsp/Kbuild
++++ b/dsp/Kbuild
+@@ -272,4 +272,5 @@ obj-$(CONFIG_MSM_QDSP6_NOTIFIER) += audio_q6_notifier.o
+ audio_q6_notifier-y := $(QDSP6_NOTIFIER_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/dsp/codecs/Kbuild b/dsp/codecs/Kbuild
+index 32366f2..a49c476 100644
+--- a/dsp/codecs/Kbuild
++++ b/dsp/codecs/Kbuild
+@@ -179,4 +179,5 @@ obj-$(CONFIG_MSM_QDSP6V2_CODECS) += audio_native.o
+ audio_native-y := $(NATIVE_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/ipc/Kbuild b/ipc/Kbuild
+index 436fbaa..e329f09 100644
+--- a/ipc/Kbuild
++++ b/ipc/Kbuild
+@@ -202,4 +202,5 @@ obj-$(CONFIG_WCD_DSP_GLINK) += wglink_dlkm.o
+ wglink_dlkm-y := $(WDSP_GLINK)
+ 
+ # inject some build related information
+-CDEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++CTIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"
+diff --git a/soc/Kbuild b/soc/Kbuild
+index aef236f..4b268d5 100644
+--- a/soc/Kbuild
++++ b/soc/Kbuild
+@@ -215,4 +215,5 @@ obj-$(CONFIG_WCD_SPI_AC) += wcd_spi_acc_ctl_dlkm.o
+ wcd_spi_acc_ctl_dlkm-y := $(WCD_SPI_ACC_CTL_OBJS)
+ 
+ # inject some build related information
+-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"
++TIMESTAMP := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
++CDEFINES += -DBUILD_TIMESTAMP=\"$(TIMESTAMP)\"

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0003-Import-beluga-makefile.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0003-Import-beluga-makefile.patch
@@ -1,0 +1,131 @@
+From bdb7ef31494468c6ed98ede80d31704e7e143d56 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Wed, 10 Jan 2024 21:58:07 +0100
+Subject: [PATCH] Import beluga makefile.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Uses a known working makefile for kernel modules but adjusts it to fit the needs for hoki.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile | 105 +++++++++++++++++++++++--------------------------------
+ 1 file changed, 44 insertions(+), 61 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index b135f46..dc8069f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,67 +1,50 @@
+-# auto-detect subdirs
+-ifeq ($(CONFIG_ARCH_SDM845), y)
+-include $(srctree)/techpack/audio/config/sdm845auto.conf
+-export
+-endif
+-ifeq ($(CONFIG_ARCH_SDM670), y)
+-include $(srctree)/techpack/audio/config/sdm670auto_static.conf
+-export
+-endif
+-ifeq ($(CONFIG_ARCH_SDXPOORWILLS), y)
+-include $(srctree)/techpack/audio/config/sdxpoorwillsauto.conf
+-export
+-endif
+-ifeq ($(CONFIG_ARCH_SM8150), y)
+-include $(srctree)/techpack/audio/config/sm8150auto.conf
+-export
+-endif
+-ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+-include $(srctree)/techpack/audio/config/sm8150auto.conf
+-export
+-endif
++AUDIO_ROOT=$(PWD)
++UAPI_OUT=$(PWD)
++HEADER_INSTALL_DIR=$(KERNEL_SRC)/scripts
++KERNEL_BINARY_DIR=$(KERNEL_SRC)/../kernel-build-artifacts
+ 
+-ifeq ($(CONFIG_ARCH_SDM429W), y)
+-include $(srctree)/techpack/audio/config/sdm450auto.conf
+-export
+-endif
++KBUILD_OPTIONS := AUDIO_ROOT=$(PWD)
++KBUILD_OPTIONS += MODNAME=audio
++KBUILD_OPTIONS += UAPI_OUT=$(PWD)
+ 
+-# Use USERINCLUDE when you must reference the UAPI directories only.
+-USERINCLUDE     += \
+-                -I$(srctree)/techpack/audio/include/uapi \
++AUDIO_KERNEL_HEADERS_PATH1 =  $(shell ls ./include/uapi/linux/*.h)
++AUDIO_KERNEL_HEADERS_PATH2 =  $(shell ls ./include/uapi/linux/mfd/wcd9xxx/*.h)
++AUDIO_KERNEL_HEADERS_PATH3 =  $(shell ls ./include/uapi/sound/*.h)
+ 
+-# Use LINUXINCLUDE when you must reference the include/ directory.
+-# Needed to be compatible with the O= option
+-LINUXINCLUDE    += \
+-                -I$(srctree)/techpack/audio/include/uapi \
+-                -I$(srctree)/techpack/audio/include
++obj-m := ipc/
++obj-m += dsp/
+ 
+-ifeq ($(CONFIG_ARCH_SDM845), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sdm845autoconf.h
+-endif
+-ifeq ($(CONFIG_ARCH_SDM670), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sdm670autoconf.h
+-endif
+-ifeq ($(CONFIG_ARCH_SDXPOORWILLS), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sdxpoorwillsautoconf.h
+-endif
+-ifeq ($(CONFIG_ARCH_SM8150), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sm8150autoconf.h
+-endif
+-ifeq ($(CONFIG_ARCH_SDMSHRIKE), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sm8150autoconf.h
+-endif
++obj-m += dsp/codecs/
+ 
+-ifeq ($(CONFIG_ARCH_SDM429W), y)
+-LINUXINCLUDE    += \
+-                -include $(srctree)/techpack/audio/config/sdm450autoconf.h
+-endif
++obj-m += soc/
++obj-m += asoc/
++obj-m += asoc/codecs/
+ 
+-obj-y += soc/
+-obj-y += dsp/
+-obj-y += ipc/
+-obj-y += asoc/
++all:
++	$(shell rm -fr $(shell pwd)/soc/core.h)
++	$(shell ln -s $(KERNEL_SRC)/drivers/pinctrl/core.h $(shell pwd)/soc/core.h)
++	$(shell rm -fr $(shell pwd)/include/soc/internal.h)
++	$(shell ln -s $(KERNEL_SRC)/drivers/base/regmap/internal.h $(shell pwd)/include/soc/internal.h)
++	$(shell rm -fr $(shell pwd)/soc/pinctrl-utils.h)
++	$(shell ln -s $(KERNEL_SRC)/drivers/pinctrl/pinctrl-utils.h $(shell pwd)/soc/pinctrl-utils.h)
++	$(shell mkdir $(shell pwd)/linux)
++	$(shell mkdir $(shell pwd)/sound)
++	$(shell mkdir $(shell pwd)/linux/mfd)
++	$(shell mkdir $(shell pwd)/linux/mfd/wcd9xxx)
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(UAPI_OUT)/linux/ $(AUDIO_ROOT)/include/uapi/linux/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH1)))
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(UAPI_OUT)/linux/mfd/wcd9xxx/ $(AUDIO_ROOT)/include/uapi/linux/mfd/wcd9xxx/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH2)))
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(UAPI_OUT)/sound/ $(AUDIO_ROOT)/include/uapi/sound/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH3)))
++	$(shell mkdir $(KERNEL_BINARY_DIR)/usr/include/sound)
++	$(shell mkdir $(KERNEL_BINARY_DIR)/usr/include/linux/mfd)
++	$(shell mkdir $(KERNEL_BINARY_DIR)/usr/include/linux/mfd/wcd9xxx)
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(KERNEL_BINARY_DIR)/usr/include/linux/ $(AUDIO_ROOT)/include/uapi/linux/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH1)))
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(KERNEL_BINARY_DIR)/usr/include/linux/mfd/wcd9xxx/ $(AUDIO_ROOT)/include/uapi/linux/mfd/wcd9xxx/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH2)))
++	$(shell cd $(KERNEL_BINARY_DIR) && $(KERNEL_SRC)/scripts/headers_install.sh $(KERNEL_BINARY_DIR)/usr/include/sound/ $(AUDIO_ROOT)/include/uapi/sound/ $(notdir $(AUDIO_KERNEL_HEADERS_PATH3)))
++	$(MAKE) -C $(KERNEL_SRC) M=$(shell pwd) modules $(KBUILD_OPTIONS)
++
++modules_install:
++	$(MAKE) INSTALL_MOD_STRIP=1 -C $(KERNEL_SRC) M=$(shell pwd) modules_install
++
++clean:
++	rm -f *.o *.ko *.mod.c *.mod.o *~ .*.cmd Module.symvers
++	rm -rf .tmp_versions

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0003-Remove-export-from-Kbuild-files.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0003-Remove-export-from-Kbuild-files.patch
@@ -1,0 +1,443 @@
+From 50277792d0c5813ab51af6f990e98bb0260e6b36 Mon Sep 17 00:00:00 2001
+From: Philip Russell <argosphil@murena.io>
+Date: Sat, 26 Aug 2023 19:56:48 +0200
+Subject: [PATCH] Remove export from Kbuild files.
+
+Fix possible host contamination.
+---
+ asoc/Kbuild                   | 14 +++++++-------
+ asoc/codecs/Kbuild            | 12 ++++++------
+ asoc/codecs/msm_bg/Kbuild     |  2 +-
+ asoc/codecs/msm_sdw/Kbuild    | 10 +++++-----
+ asoc/codecs/sdm660_cdc/Kbuild | 12 ++++++------
+ asoc/codecs/tfa98xx/Kbuild    | 12 ++++++------
+ asoc/codecs/wcd934x/Kbuild    |  4 ++--
+ dsp/Kbuild                    | 12 ++++++------
+ dsp/codecs/Kbuild             | 12 ++++++------
+ ipc/Kbuild                    | 12 ++++++------
+ soc/Kbuild                    | 12 ++++++------
+ 11 files changed, 57 insertions(+), 57 deletions(-)
+
+diff --git a/asoc/Kbuild b/asoc/Kbuild
+index 4ce067c..2a3c7c7 100755
+--- a/asoc/Kbuild
++++ b/asoc/Kbuild
+@@ -17,37 +17,37 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDXPOORWILLS), y)
+ 		include $(AUDIO_ROOT)/config/sdxpoorwillsauto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdxpoorwillsautoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/Kbuild b/asoc/codecs/Kbuild
+index fbadc74..670f55e 100755
+--- a/asoc/codecs/Kbuild
++++ b/asoc/codecs/Kbuild
+@@ -16,32 +16,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/msm_bg/Kbuild b/asoc/codecs/msm_bg/Kbuild
+index 37f7d51..013c52e 100755
+--- a/asoc/codecs/msm_bg/Kbuild
++++ b/asoc/codecs/msm_bg/Kbuild
+@@ -8,7 +8,7 @@ ifeq ($(KERNEL_BUILD), 0)
+ 	# Need to explicitly configure for Android-based builds
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 	endif
+ endif
+ 
+diff --git a/asoc/codecs/msm_sdw/Kbuild b/asoc/codecs/msm_sdw/Kbuild
+index 7bd2f5d..188272b 100755
+--- a/asoc/codecs/msm_sdw/Kbuild
++++ b/asoc/codecs/msm_sdw/Kbuild
+@@ -17,27 +17,27 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/sdm660_cdc/Kbuild b/asoc/codecs/sdm660_cdc/Kbuild
+index 6bf49b9..621d239 100755
+--- a/asoc/codecs/sdm660_cdc/Kbuild
++++ b/asoc/codecs/sdm660_cdc/Kbuild
+@@ -17,32 +17,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/tfa98xx/Kbuild b/asoc/codecs/tfa98xx/Kbuild
+index 61dd04b..4f7de12 100755
+--- a/asoc/codecs/tfa98xx/Kbuild
++++ b/asoc/codecs/tfa98xx/Kbuild
+@@ -17,32 +17,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ endif
+diff --git a/asoc/codecs/wcd934x/Kbuild b/asoc/codecs/wcd934x/Kbuild
+index 6b35acd..e6f5399 100644
+--- a/asoc/codecs/wcd934x/Kbuild
++++ b/asoc/codecs/wcd934x/Kbuild
+@@ -18,12 +18,12 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ endif
+diff --git a/dsp/Kbuild b/dsp/Kbuild
+index 3ea996b..6e01357 100755
+--- a/dsp/Kbuild
++++ b/dsp/Kbuild
+@@ -16,32 +16,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/dsp/codecs/Kbuild b/dsp/codecs/Kbuild
+index d521182..dc1d43d 100755
+--- a/dsp/codecs/Kbuild
++++ b/dsp/codecs/Kbuild
+@@ -16,33 +16,33 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/ipc/Kbuild b/ipc/Kbuild
+index b4a0f98..bd28125 100755
+--- a/ipc/Kbuild
++++ b/ipc/Kbuild
+@@ -38,32 +38,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+diff --git a/soc/Kbuild b/soc/Kbuild
+index cc2e38e..7241f84 100755
+--- a/soc/Kbuild
++++ b/soc/Kbuild
+@@ -16,32 +16,32 @@ endif
+ ifeq ($(KERNEL_BUILD), 0)
+ 	ifeq ($(CONFIG_ARCH_SDM845), y)
+ 		include $(AUDIO_ROOT)/config/sdm845auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm845autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM670), y)
+ 		include $(AUDIO_ROOT)/config/sdm710auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm710autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM450), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_SDM439), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8909), y)
+ 		include $(AUDIO_ROOT)/config/msm8909auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/msm8909autoconf.h
+ 	endif
+ 	ifeq ($(CONFIG_ARCH_MSM8917), y)
+ 		include $(AUDIO_ROOT)/config/sdm450auto.conf
+-		export
++		
+ 		INCS    +=  -include $(AUDIO_ROOT)/config/sdm450autoconf.h
+ 	endif
+ endif
+-- 
+2.42.0
+

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0004-Ignore-compilation-warnings.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0004-Ignore-compilation-warnings.patch
@@ -1,0 +1,77 @@
+From 9e86dee81292384b1aa46b1e6a9969209ada6975 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Wed, 10 Jan 2024 22:00:57 +0100
+Subject: [PATCH] Ignore compilation warnings.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ asoc/Kbuild        | 1 -
+ asoc/codecs/Kbuild | 1 -
+ dsp/Kbuild         | 1 -
+ dsp/codecs/Kbuild  | 1 -
+ soc/Kbuild         | 1 -
+ 5 files changed, 5 deletions(-)
+
+diff --git a/asoc/Kbuild b/asoc/Kbuild
+index 9beb346..e9737f9 100644
+--- a/asoc/Kbuild
++++ b/asoc/Kbuild
+@@ -229,7 +229,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
+ 		-DANI_OS_TYPE_ANDROID=6 \
+ 		-DPTT_SOCK_SVC_ENABLE \
+ 		-Wall\
+-		-Werror\
+ 		-D__linux__
+ 
+ KBUILD_CPPFLAGS += $(CDEFINES)
+diff --git a/asoc/codecs/Kbuild b/asoc/codecs/Kbuild
+index 5bd1d98..ef8323c 100644
+--- a/asoc/codecs/Kbuild
++++ b/asoc/codecs/Kbuild
+@@ -200,7 +200,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
+ 		-DANI_OS_TYPE_ANDROID=6 \
+ 		-DPTT_SOCK_SVC_ENABLE \
+ 		-Wall\
+-		-Werror\
+ 		-D__linux__
+ 
+ KBUILD_CPPFLAGS += $(CDEFINES)
+diff --git a/dsp/Kbuild b/dsp/Kbuild
+index 650c7be..08d32b2 100644
+--- a/dsp/Kbuild
++++ b/dsp/Kbuild
+@@ -207,7 +207,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
+ 		-DANI_OS_TYPE_ANDROID=6 \
+ 		-DPTT_SOCK_SVC_ENABLE \
+ 		-Wall\
+-		-Werror\
+ 		-D__linux__
+ 
+ KBUILD_CPPFLAGS += $(CDEFINES)
+diff --git a/dsp/codecs/Kbuild b/dsp/codecs/Kbuild
+index a49c476..d00f6ca 100644
+--- a/dsp/codecs/Kbuild
++++ b/dsp/codecs/Kbuild
+@@ -142,7 +142,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
+ 		-DANI_OS_TYPE_ANDROID=6 \
+ 		-DPTT_SOCK_SVC_ENABLE \
+ 		-Wall\
+-		-Werror\
+ 		-D__linux__
+ 
+ KBUILD_CPPFLAGS += $(CDEFINES)
+diff --git a/soc/Kbuild b/soc/Kbuild
+index 4b268d5..9df7ed3 100644
+--- a/soc/Kbuild
++++ b/soc/Kbuild
+@@ -164,7 +164,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
+ 		-DANI_OS_TYPE_ANDROID=6 \
+ 		-DPTT_SOCK_SVC_ENABLE \
+ 		-Wall\
+-		-Werror\
+ 		-D__linux__
+ 
+ KBUILD_CPPFLAGS += $(CDEFINES)

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0005-dsp-Compile-codecs-for-out-of-tree-builds.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0005-dsp-Compile-codecs-for-out-of-tree-builds.patch
@@ -1,0 +1,28 @@
+From 3ad3f67492cd49f7a35174bde51377018a72c2bd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Wed, 10 Jan 2024 22:01:15 +0100
+Subject: [PATCH] dsp: Compile codecs for out-of-tree builds.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ dsp/Kbuild | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/dsp/Kbuild b/dsp/Kbuild
+index 08d32b2..4571e50 100644
+--- a/dsp/Kbuild
++++ b/dsp/Kbuild
+@@ -244,9 +244,7 @@ ifeq ($(KERNEL_BUILD), 0)
+ 
+ endif
+ 
+-ifeq ($(KERNEL_BUILD), 1)
+-	obj-y += codecs/
+-endif
++obj-y += codecs/
+ 
+ ifeq ($(CONFIG_SND_SOC_GCOV), y)
+ GCOV_PROFILE := y

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bb
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bb
@@ -1,0 +1,40 @@
+SUMMARY = "External audio modules for beluga"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://NOTICE;md5=53c09804050a00b1d27bd609c4e1fc5a"
+COMPATIBLE_MACHINE = "hoki"
+
+inherit module kernel-module-split
+
+SRC_URI = "git://github.com/fossil-engineering/kernel-msm-fossil-extra-cw-audiokernel;branch=fossil-android-msm-hoki-lw1.2-4.14;protocol=https \
+           file://0001-Remove-export-from-Kbuild-files.patch \
+           file://0002-Avoid-shell-expansion-in-recursively-expanded-variab.patch \
+           file://0003-Import-beluga-makefile.patch \
+           file://0004-Ignore-compilation-warnings.patch \
+           file://0005-dsp-Compile-codecs-for-out-of-tree-builds.patch \
+           "
+SRCREV = "c984389253fc58bc316af06bf3504dd2c25382be"
+LINUX_VERSION ?= "4.9"
+PV = "${LINUX_VERSION}+pie"
+S = "${WORKDIR}/git"
+B = "${S}"
+
+DEPENDS = "virtual/kernel"
+
+EXTRA_OEMAKE = " KERNEL_SRC="${STAGING_KERNEL_DIR}" M="${S}""
+
+RPROVIDES:${PN} += "kernel-module-audio-apr"
+RPROVIDES:${PN} += "kernel-module-audio-pinctrl-wcd"
+RPROVIDES:${PN} += "kernel-module-audio-swr-ctrl"
+RPROVIDES:${PN} += "kernel-module-audio-swr"
+RPROVIDES:${PN} += "kernel-module-audio-q6"
+RPROVIDES:${PN} += "kernel-module-audio-adsp-loader"
+RPROVIDES:${PN} += "kernel-module-audio-usf"
+RPROVIDES:${PN} += "kernel-module-audio-q6-notifier"
+RPROVIDES:${PN} += "kernel-module-audio-machine"
+RPROVIDES:${PN} += "kernel-module-audio-stub"
+RPROVIDES:${PN} += "kernel-module-audio-wsa881x"
+RPROVIDES:${PN} += "kernel-module-audio-mbhc"
+RPROVIDES:${PN} += "kernel-module-audio-wcd-core"
+RPROVIDES:${PN} += "kernel-module-audio-wsa881x-analog"
+RPROVIDES:${PN} += "kernel-module-audio-wcd9xxx"
+RPROVIDES:${PN} += "kernel-module-audio-platform"


### PR DESCRIPTION
Provides the audio kernel modules to allow booting the modem.
Then start the required Android services to get sensors to work.

Audio isn't functional at this point, I suspect that this is because the Android R firmware is loaded on an Android Pie base, which may require a different audio routing.

This depends on https://github.com/AsteroidOS/meta-asteroid/pull/182.

This solves #185.