### PR TITLE
anthias, lenok, sparrow, sprat, wren: asteroid-launcher-configs: Provide device configuration.

### DIFF
--- a/meta-anthias/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-anthias/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,0 +1,5 @@
+EGL_PLATFORM=hwcomposer
+QT_QPA_PLATFORM=hwcomposer
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_IM_MODULE=qtvirtualkeyboard
+QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc

--- a/meta-anthias/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
+++ b/meta-anthias/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:anthias := "${THISDIR}/asteroid-launcher-configs:"

--- a/meta-lenok/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-lenok/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,0 +1,5 @@
+EGL_PLATFORM=hwcomposer
+QT_QPA_PLATFORM=hwcomposer
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_IM_MODULE=qtvirtualkeyboard
+QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc

--- a/meta-lenok/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
+++ b/meta-lenok/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:lenok := "${THISDIR}/asteroid-launcher-configs:"

--- a/meta-sparrow/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-sparrow/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,0 +1,5 @@
+EGL_PLATFORM=hwcomposer
+QT_QPA_PLATFORM=hwcomposer
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_IM_MODULE=qtvirtualkeyboard
+QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc

--- a/meta-sparrow/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
+++ b/meta-sparrow/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:sparrow := "${THISDIR}/asteroid-launcher-configs:"

--- a/meta-sprat/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-sprat/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,0 +1,5 @@
+EGL_PLATFORM=hwcomposer
+QT_QPA_PLATFORM=hwcomposer
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_IM_MODULE=qtvirtualkeyboard
+QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc

--- a/meta-sprat/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
+++ b/meta-sprat/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:sprat := "${THISDIR}/asteroid-launcher-configs:"

--- a/meta-wren/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-wren/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,0 +1,5 @@
+EGL_PLATFORM=hwcomposer
+QT_QPA_PLATFORM=hwcomposer
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_IM_MODULE=qtvirtualkeyboard
+QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc

--- a/meta-wren/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
+++ b/meta-wren/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:wren := "${THISDIR}/asteroid-launcher-configs:"


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-asteroid/commit/967c9afa70240cbdaf6dd28465e3b74d361f6d1d removed  the default configuration, requiring a machine specific configuration for hybris devices.
This provides the configuration needed for `anthias`, `lenok`, `sparrow`, `sprat` and`wren`.

This fixes https://github.com/AsteroidOS/meta-smartwatch/issues/240.