### PR TITLE
hoki: Fix NFC.

### DIFF
--- a/meta-hoki/recipes-android/android-init/android-init/init.rc
+++ b/meta-hoki/recipes-android/android-init/android-init/init.rc
@@ -73,6 +73,9 @@ service vendor.per_proxy /system/vendor/bin/pm-proxy
 service sidekickgraphics-hal-1-2 /vendor/bin/hw/vendor.qti.hardware.sidekickgraphics@1.2-service
     class hal
 
+service nfc_hal_service /vendor/bin/hw/android.hardware.nfc@1.1-service
+    class hal
+
 service vendor.sensors-hal-1-0 /vendor/bin/hw/android.hardware.sensors@1.0-service
     class hal
     oneshot

--- a/meta-hoki/recipes-nemomobile/libnci/libncicore/libncicore.conf
+++ b/meta-hoki/recipes-nemomobile/libnci/libncicore/libncicore.conf
@@ -1,0 +1,2 @@
+[Configuration]
+Technologies = A,B

--- a/meta-hoki/recipes-nemomobile/libnci/libncicore_git.bbappend
+++ b/meta-hoki/recipes-nemomobile/libnci/libncicore_git.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend:hoki := "${THISDIR}/${PN}:"
+SRC_URI:append:hoki = " file://libncicore.conf"
+
+do_install:append:hoki() {
+    install -d ${D}${sysconfdir}
+    install -m 0666 ${WORKDIR}/libncicore.conf ${D}${sysconfdir}/libncicore.conf
+}


### PR DESCRIPTION
Starts the needed NFC Android daemon and provides a configuration such that NFC works.

The NFC daemon is disabled, but manually starting it is enough to get it to work.
On `hoki` graphical issues are also observed when scanning a tag (similar to https://github.com/AsteroidOS/meta-asteroid/pull/178).