### PR TITLE
beluga: initrdscripts: Add init.machine to main package

### DIFF
--- a/meta-beluga/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-beluga/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -9,5 +9,5 @@ do_install:append:beluga() {
 }
 
 RDEPENDS:${PN}:append:beluga = " msm-fb-refresher"
-FILES:${PN}:append:beluga = " /ld.config.28.txt"
+FILES:${PN}:append:beluga = " /ld.config.28.txt /init.machine"
 


### PR DESCRIPTION
Without this, a Yocto Scarthgap build will fail with and installed-vs-shipped QA issue because init.machines is not automatically added to ${PN}.