### PR TITLE
WIP: initrdscripts: Fix init.machine FILES variable pollution

### DIFF
--- a/meta-lenok/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-lenok/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -7,4 +7,4 @@ do_install:append:lenok() {
     install -m 0755 ${WORKDIR}/init.machine.sh ${D}/init.machine
 }
 
-FILES:${PN} += "/init.machine"
+FILES:${PN}:append:lenok = "/init.machine"

--- a/meta-sawfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-sawfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -7,4 +7,4 @@ do_install:append:sawfish() {
     install -m 0755 ${WORKDIR}/init.machine.sh ${D}/init.machine
 }
 
-FILES:${PN} += "/init.machine"
+FILES:${PN}:append:sawfish = "/init.machine"

--- a/meta-sturgeon/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-sturgeon/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -7,4 +7,4 @@ do_install:append:sturgeon() {
     install -m 0755 ${WORKDIR}/init.machine.sh ${D}/init.machine
 }
 
-FILES:${PN} += "/init.machine"
+FILES:${PN}:append:sturgeon = "/init.machine"


### PR DESCRIPTION
Several initrd scripts pollute FILES:${PN} by adding init.machine, which ends up masking errors in other smartwatch specific bbappends, specifically that they are missing their own init.machine addition. This means that if only one smartwatch layer is used, this pollution can cause build errors because init.machine is not added properly.

Marked as WIP because up until now, other layers may have inadvertedly relied on that pollution, so this commit may cause a build failure due to the now-missing init.machine inclusion. The proper fix is to add `FILES:${PN}:append:<machine name> = "/init.machine"` lines to all layers.