### PR TITLE
triggerfish: Include hoki initramfs patch

### DIFF
--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish/0005-initramfs-Don-t-skip-initramfs.patch
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish/0005-initramfs-Don-t-skip-initramfs.patch
@@ -1,0 +1,25 @@
+From 719ae887caf99550c5361aa4ac544ede1303f40d Mon Sep 17 00:00:00 2001
+From: MagneFire <dgriet@gmail.com>
+Date: Tue, 26 Apr 2022 22:10:42 +0200
+Subject: [PATCH] initramfs: Don't skip initramfs.
+
+---
+ init/initramfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/init/initramfs.c b/init/initramfs.c
+index bf3af10c500a..f022ba0faba3 100644
+--- a/init/initramfs.c
++++ b/init/initramfs.c
+@@ -613,7 +613,7 @@ static int __init skip_initramfs_param(char *str)
+ {
+ 	if (*str)
+ 		return 0;
+-	do_skip_initramfs = 1;
++	//do_skip_initramfs = 1;
+ 	return 1;
+ }
+ __setup("skip_initramfs", skip_initramfs_param);
+-- 
+2.35.1
+

--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-triggerf
            file://0002-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
            file://0003-Force-triggerfish-DTB-to-build.patch \
            file://0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           file://0005-initramfs-Don-t-skip-initramfs.patch \
            "
 
 SRCREV = "82824770e036a1e7576a299bc37b52d633d62675"


### PR DESCRIPTION
Patch and direction by @MagneFire, this gets `triggerfish` to a booting (albeit poor) state. Tested with a Fossil 5 Julianna.