### PR TITLE
triggerfish: Add basic wifi support

### DIFF
--- a/meta-triggerfish/conf/machine/triggerfish.conf
+++ b/meta-triggerfish/conf/machine/triggerfish.conf
@@ -17,4 +17,4 @@ PREFERRED_VERSION_android = "armv7+pie64"
 PREFERRED_PROVIDER_virtual/kernel = "linux-triggerfish"
 PREFERRED_VERSION_linux = "4.9+pie"
 
-IMAGE_INSTALL += "sensorfw-hybris-hal-plugins underclock udev-droid-system bluebinder asteroid-hrm asteroid-compass"
+IMAGE_INSTALL += "sensorfw-hybris-hal-plugins linux-wlan-modules-triggerfish util-linux-rfkill underclock udev-droid-system bluebinder asteroid-hrm asteroid-compass"

--- a/meta-triggerfish/recipes-core/base-files/base-files/fstab
+++ b/meta-triggerfish/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,7 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+/dev/mmcblk0p24      /persist             auto       defaults              0  0
+/dev/mmcblk0p1       /firmware            auto       ro,shortname=lower    0  0

--- a/meta-triggerfish/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-triggerfish/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend:triggerfish := "${THISDIR}/${PN}:"
+COMPATIBLE_MACHINE:triggerfish = "triggerfish"

--- a/meta-triggerfish/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
+++ b/meta-triggerfish/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
@@ -1,0 +1,8 @@
+do_configure:triggerfish() {
+    # Override the targets to be used before compiling kernel modules.
+    # Remove the 'prepare' target as it would fail.
+    unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
+    oe_runmake CC="${KERNEL_CC}" LD="${KERNEL_LD}" \
+    AR="${KERNEL_AR}" OBJCOPY="${KERNEL_OBJCOPY}" \
+    -C ${STAGING_KERNEL_DIR} O=${STAGING_KERNEL_BUILDDIR} scripts
+}

--- a/meta-triggerfish/recipes-kernel/modules/linux-wlan-modules-triggerfish/wlan-module-load.service
+++ b/meta-triggerfish/recipes-kernel/modules/linux-wlan-modules-triggerfish/wlan-module-load.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Setup wifi firmware and load the wlan kernel module
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/sh -c "/bin/echo > /dev/wcnss_wlan"
+ExecStart=/sbin/modprobe wlan
+ExecStart=/sbin/rfkill unblock wlan
+
+[Install]
+WantedBy=basic.target

--- a/meta-triggerfish/recipes-kernel/modules/linux-wlan-modules-triggerfish_p.bb
+++ b/meta-triggerfish/recipes-kernel/modules/linux-wlan-modules-triggerfish_p.bb
@@ -1,0 +1,28 @@
+SUMMARY = "External WLAN module for triggerfish"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://CORE/HDD/inc/wlan_hdd_main.h;beginline=1;endline=26;md5=7692d0637ca32118ead3cb480cff3f2f"
+COMPATIBLE_MACHINE = "triggerfish"
+
+inherit module kernel-module-split systemd
+
+SRC_URI = " git://android.googlesource.com/kernel/msm-modules/wlan;branch=android-msm-sole-4.9-pie-wear-mr1;protocol=https \
+    file://wlan-module-load.service"
+SRCREV = "207571b39e06ee3d8ff7d64d3062eb037a696532"
+LINUX_VERSION ?= "4.9"
+PV = "${LINUX_VERSION}+pie"
+S = "${WORKDIR}/git"
+B = "${S}"
+
+DEPENDS = "virtual/kernel virtual/${TARGET_PREFIX}gcc"
+
+EXTRA_OEMAKE = " KERNEL_SRC="${STAGING_KERNEL_DIR}" M="${S}""
+
+RPROVIDES:${PN} += "kernel-module-wlan"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "wlan-module-load.service"
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 644 -D ${WORKDIR}/wlan-module-load.service ${D}${systemd_system_unitdir}/wlan-module-load.service
+}


### PR DESCRIPTION
This commit adds basic wifi functionality to the fossil gen 5 triggerfish in order for configuration via connman / wpa_supplicant to work.

To do that firmware blobs are now mounted at the correct location where they can be found via firmwared.
An external kernel module 'wlan' to provide the interface is included and loaded at startup

Enjoy :D