### PR TITLE
meta-tetra/mtk6580: qml-asteroid: Add disable spinner shaders patch

### DIFF
--- a/meta-mtk6580/recipes-asteroid/qml-asteroid/qml-asteroid/0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch
+++ b/meta-mtk6580/recipes-asteroid/qml-asteroid/qml-asteroid/0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch
@@ -1,0 +1,39 @@
+From 72ce1af1dda062594003083494e0c99111649234 Mon Sep 17 00:00:00 2001
+From: Florent Revest <revestflo@gmail.com>
+Date: Sun, 3 Dec 2017 00:37:37 +0100
+Subject: [PATCH] Spinners: Disable shaders which cause all sorts of problems
+ on tetra
+
+Upstream-Status: Inappropriate
+
+---
+ src/controls/qml/CircularSpinner.qml | 2 +-
+ src/controls/qml/Spinner.qml         | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/controls/qml/CircularSpinner.qml b/src/controls/qml/CircularSpinner.qml
+index 2dc3c6b..db19f83 100644
+--- a/src/controls/qml/CircularSpinner.qml
++++ b/src/controls/qml/CircularSpinner.qml
+@@ -45,7 +45,7 @@ PathView {
+         visible: false
+     }
+
+-    layer.enabled: true
++    layer.enabled: false
+     layer.effect: ShaderEffect {
+         fragmentShader: "
+         precision mediump float;
+diff --git a/src/controls/qml/Spinner.qml b/src/controls/qml/Spinner.qml
+index b7cd76b..62be3ec 100644
+--- a/src/controls/qml/Spinner.qml
++++ b/src/controls/qml/Spinner.qml
+@@ -40,7 +40,7 @@ ListView {
+         visible: false
+     }
+
+-    layer.enabled: true
++    layer.enabled: false
+     layer.effect: ShaderEffect {
+         fragmentShader: "
+         precision mediump float;

--- a/meta-tetra/recipes-asteroid/qml-asteroid/qml-asteroid/0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch
+++ b/meta-tetra/recipes-asteroid/qml-asteroid/qml-asteroid/0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch
@@ -1,0 +1,39 @@
+From 72ce1af1dda062594003083494e0c99111649234 Mon Sep 17 00:00:00 2001
+From: Florent Revest <revestflo@gmail.com>
+Date: Sun, 3 Dec 2017 00:37:37 +0100
+Subject: [PATCH] Spinners: Disable shaders which cause all sorts of problems
+ on tetra
+
+Upstream-Status: Inappropriate
+
+---
+ src/controls/qml/CircularSpinner.qml | 2 +-
+ src/controls/qml/Spinner.qml         | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/controls/qml/CircularSpinner.qml b/src/controls/qml/CircularSpinner.qml
+index 2dc3c6b..db19f83 100644
+--- a/src/controls/qml/CircularSpinner.qml
++++ b/src/controls/qml/CircularSpinner.qml
+@@ -45,7 +45,7 @@ PathView {
+         visible: false
+     }
+
+-    layer.enabled: true
++    layer.enabled: false
+     layer.effect: ShaderEffect {
+         fragmentShader: "
+         precision mediump float;
+diff --git a/src/controls/qml/Spinner.qml b/src/controls/qml/Spinner.qml
+index b7cd76b..62be3ec 100644
+--- a/src/controls/qml/Spinner.qml
++++ b/src/controls/qml/Spinner.qml
+@@ -40,7 +40,7 @@ ListView {
+         visible: false
+     }
+
+-    layer.enabled: true
++    layer.enabled: false
+     layer.effect: ShaderEffect {
+         fragmentShader: "
+         precision mediump float;


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-asteroid/commit/63246a3e893d80882c46096a883bcb6446b6525b moved the patch file from meta-asteroid to meta-smartwatch. But then only to the emulator platform.

However, this patch is also used by the tetra and mtk6580 platforms. This adds them, to make qml-asteroid correctly configure.