### PR TITLE
tetra: qml-asteroid: Prepend patches path

### DIFF
--- a/meta-tetra/recipes-asteroid/qml-asteroid/qml-asteroid_%.bbappend
+++ b/meta-tetra/recipes-asteroid/qml-asteroid/qml-asteroid_%.bbappend
@@ -1,1 +1,3 @@
+FILESEXTRAPATHS:prepend:tetra := "${THISDIR}/qml-asteroid:"
+
 SRC_URI:append:tetra = " file://0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch"


### PR DESCRIPTION
This fixes an issue where qml-asteroid can not be built due to the missing search path.