### PR TITLE
Add link to Ticwatch C2 on the product page section

### DIFF
--- a/meta-skipjack/README.md
+++ b/meta-skipjack/README.md
@@ -15,3 +15,4 @@ https://www.youtube.com/watch?v=C7DH4V8kl48
 ==Product Page==
 
 https://www.mobvoi.com/us/pages/ticwatchc2plus
+https://www.mobvoi.com/us/pages/ticwatchc2


### PR DESCRIPTION
Possibly the most useless PR ever made, but creating it anyways. skipjack is both C2 and C2+.