### PR TITLE
hoki/triggerfish: initrdscripts: Install machine init script

### DIFF
--- a/meta-hoki/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-hoki/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -8,3 +8,5 @@ do_install:append:hoki() {
 
 RDEPENDS:${PN}:append:hoki = " msm-fb-refresher"
 
+FILES:${PN}:append:hoki = " /init.machine"
+

--- a/meta-triggerfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
+++ b/meta-triggerfish/recipes-core/initrdscripts/initramfs-scripts-android_1.0.bbappend
@@ -9,4 +9,4 @@ do_install:append:triggerfish() {
 }
 
 RDEPENDS:${PN}:append:triggerfish = " msm-fb-refresher"
-FILES:${PN}:append:triggerfish = " /ld.config.28.txt"
+FILES:${PN}:append:triggerfish = " /ld.config.28.txt /init.machine"


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-smartwatch/commit/556f3ea5969ab46c2180bd905bc37c2a2efa9c9a solved a FILES variable pollution issue.
This highlighted an issue where hoki and triggerfish both install a custom `init.machine.sh` but it's not actually appended to the FILES variable.

This corrects this issue.