### PR TITLE
Fix package installation to /usr/bin, not /bin

### DIFF
--- a/meta-catfish/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/meta-catfish/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -9,6 +9,6 @@ UNPACKDIR = "${S}"
 B = "${S}"
 
 do_install:append() {
-    install -d ${D}/lib/udev/rules.d
-    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}/lib/udev/rules.d/
+    install -d ${D}${libdir}/udev/rules.d
+    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}${libdir}/udev/rules.d/
 }

--- a/meta-hoki/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/meta-hoki/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -9,6 +9,6 @@ UNPACKDIR = "${S}"
 B = "${S}"
 
 do_install:append() {
-    install -d ${D}/lib/udev/rules.d
-    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}/lib/udev/rules.d/
+    install -d ${D}${libdir}/udev/rules.d
+    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}${libdir}/udev/rules.d/
 }

--- a/meta-narwhal/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/meta-narwhal/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -9,6 +9,6 @@ UNPACKDIR = "${S}"
 B = "${S}"
 
 do_install:append() {
-    install -d ${D}/lib/udev/rules.d
-    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}/lib/udev/rules.d/
+    install -d ${D}${libdir}/udev/rules.d
+    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}${libdir}/udev/rules.d/
 }

--- a/meta-ray/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/meta-ray/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -9,6 +9,6 @@ UNPACKDIR = "${S}"
 B = "${S}"
 
 do_install:append() {
-    install -d ${D}/lib/udev/rules.d
-    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}/lib/udev/rules.d/
+    install -d ${D}${libdir}/udev/rules.d
+    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}${libdir}/udev/rules.d/
 }

--- a/meta-skipjack/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/meta-skipjack/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -9,6 +9,6 @@ UNPACKDIR = "${S}"
 B = "${S}"
 
 do_install:append() {
-    install -d ${D}/lib/udev/rules.d
-    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}/lib/udev/rules.d/
+    install -d ${D}${libdir}/udev/rules.d
+    install -m 644 ${UNPACKDIR}/998-droid-system.rules ${D}${libdir}/udev/rules.d/
 }


### PR DESCRIPTION
Since the usr merge in 2012 (see https://fedoraproject.org/wiki/Features/UsrMove), all Linux systems should install to /usr/bin rather than /bin which is now just a symlink to /usr/bin.  This corrects a few scripts to make sure they pass Yocto qa tests.