### PR TITLE
[hoki] fix the underclock script

### DIFF
--- a/meta-hoki/recipes-core/underclock/underclock/underclock
+++ b/meta-hoki/recipes-core/underclock/underclock/underclock
@@ -1,18 +1,14 @@
 #!/bin/sh
+set -e
+
+# Enable low power mode
+echo 0 > /sys/module/lpm_levels/parameters/sleep_disabled
+
+# Set CPU governor to ondemand (ramps up quickly for bursty workloads)
+echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 
 # Disable three cores
-echo 0        > /sys/module/lpm_levels/parameters/sleep_disabled
-echo 0        > /sys/devices/system/cpu/cpu1/online
-echo 0        > /sys/devices/system/cpu/cpu2/online
-echo 0        > /sys/devices/system/cpu/cpu3/online
+echo 0 > /sys/devices/system/cpu/cpu1/online
+echo 0 > /sys/devices/system/cpu/cpu2/online
+echo 0 > /sys/devices/system/cpu/cpu3/online
 
-# Allow the GPU to switch frequencies.
-echo 307200000   > /sys/class/kgsl/kgsl-3d0/devfreq/max_freq
-echo 19200000    > /sys/class/kgsl/kgsl-3d0/devfreq/min_freq
-echo msm-adreno-tz > /sys/class/kgsl/kgsl-3d0/devfreq/governor
-
-# CPU IDLE Low Power Mode config
-echo 1 > /sys/module/lpm_levels/system/cpu0/pc/suspend_enabled
-echo 1 > /sys/module/lpm_levels/system/cpu0/standalone_pc/suspend_enabled
-echo 1 > /sys/module/lpm_levels/system/cpu0/standalone_pc/idle_enabled
-echo 1 > /sys/module/lpm_levels/system/cpu0/pc/idle_enabled


### PR DESCRIPTION
closes https://github.com/AsteroidOS/meta-smartwatch/issues/290

Hoki is the only watch I own and can test, this might be also appropriate for other models.

I've added ``set -e`` so it fails early and loud - with that, an error here would be visible as a failed service (if/when someone looks at the list of services). Without it, you may only notice it by directly checking CPU frequencies at runtime.

The GPU only has a single operating frequency:

```sh
$ adb shell cat /sys/class/kgsl/kgsl-3d0/gpu_available_frequencies
320000000 
```

so I've removed that block.

The previously last section was a) incorrect (failing) and b) unnecessary, because the kernel defaults them to enabled:

https://raw.githubusercontent.com/fossil-engineering/kernel-msm-fossil-cw/c0b4c201f2d5a641defe19958a9b4c16f40d866b/drivers/cpuidle/lpm-levels-of.c


```c
avail->idle_enabled = true;
avail->suspend_enabled = true;
```


(confirmed at runtime, I disabled the service and rebooted:)

```
$ adb shell 'for p in /sys/module/lpm_levels/system/*/idle_enabled /sys/module/lpm_levels/system/*/suspend_enabled; do echo "$p = $(cat $p)"; done'
/sys/module/lpm_levels/system/system-pc/idle_enabled = Y
/sys/module/lpm_levels/system/system-ret/idle_enabled = Y
/sys/module/lpm_levels/system/system-wfi/idle_enabled = Y
/sys/module/lpm_levels/system/system-pc/suspend_enabled = Y
/sys/module/lpm_levels/system/system-ret/suspend_enabled = Y
/sys/module/lpm_levels/system/system-wfi/suspend_enabled = Y
```

Alternatively, if you wanted to reuse one script for multiple watches and kernels, you could use

```sh
for p in /sys/module/lpm_levels/system/*/idle_enabled \
         /sys/module/lpm_levels/system/*/suspend_enabled; do
    [ -w "$p" ] && echo 1 > "$p" 2>/dev/null
done
```