### PR TITLE
emulator: use virtio-vga-gl as sole display device

### DIFF
--- a/meta-emulator/conf/machine/emulator.conf
+++ b/meta-emulator/conf/machine/emulator.conf
@@ -21,3 +21,6 @@ KMACHINE = "qemux86"
 PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append = " kernel-modules "
 MACHINE_ESSENTIAL_EXTRA_RECOMMENDS:append = " kernel-modules "
+
+QB_GRAPHICS = "-vga none -device virtio-vga-gl"
+QB_OPT_APPEND:append = " -display gtk,gl=on,show-cursor=on"


### PR DESCRIPTION
The default qemux86 config creates a bochs VGA alongside virtio-gpu, producing two DRM devices. The text console renders on bochs while the AsteroidOS compositor renders on virtio-gpu, so users only see a login prompt instead of the watch UI when running the emulator.

This disables the default VGA and uses virtio-vga-gl as the only GPU, which also enables virgl 3D acceleration via the GTK display backend.

Related to https://github.com/AsteroidOS/asteroid-launcher/pull/218