### PR TITLE
emulator: enable absolute mouse coordinates for QEMU USB tablet

### DIFF
--- a/meta-emulator/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/meta-emulator/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -2,3 +2,4 @@ QT_QPA_PLATFORM=eglfs
 QT_QPA_EGLFS_INTEGRATION=eglfs_kms
 QT_IM_MODULE=qtvirtualkeyboard
 QT_QPA_EGLFS_KMS_CONFIG=/var/lib/environment/compositor/kms.json
+QT_QPA_EVDEV_MOUSE_PARAMETERS=/dev/input/event1:abs


### PR DESCRIPTION
QEMU's virtual mouse sends position as exact screen coordinates (like 'the cursor is at position 16383 out of 32767'). But Qt thinks these numbers are movement amounts (like 'move the cursor 16383 pixels to the right'). This makes every click land in the wrong spot -- usually stuck at the edges of the screen. Nothing is clickable.

The fix adds one setting to tell Qt to read the mouse position correctly. After this, clicks land where you actually click, buttons work, scrolling works.

Only affects the emulator. Real watches use touchscreens, not a mouse, so this changes nothing for them.

It is nice now, I'm using this QEMU image , this will help us move much quicker developing hte UI, I found some memory leaks since now you can run tests and profile the image