### PR TITLE
Move per-device lipstick bbappends to asteroid-launcher

### DIFF
--- a/meta-anthias/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-anthias/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:anthias = " qt6-qpa-hwcomposer-plugin "

--- a/meta-aurora/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-aurora/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:aurora = " qt6-qpa-hwcomposer-plugin "

--- a/meta-bass/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-bass/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:bass = " qt6-qpa-hwcomposer-plugin "

--- a/meta-beluga/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-beluga/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:beluga = " qt6-qpa-hwcomposer-plugin "

--- a/meta-catfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-catfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:catfish = " qt6-qpa-hwcomposer-plugin "

--- a/meta-dory/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-dory/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:dory = " qt6-qpa-hwcomposer-plugin "

--- a/meta-hoki/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-hoki/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:hoki = " qt6-qpa-hwcomposer-plugin "

--- a/meta-koi/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-koi/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:koi = " qt6-qpa-hwcomposer-plugin "

--- a/meta-lenok/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-lenok/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:lenok = " qt6-qpa-hwcomposer-plugin "

--- a/meta-minnow/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-minnow/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:minnow = " qt6-qpa-hwcomposer-plugin "

--- a/meta-mooneye/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-mooneye/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:mooneye = " qt6-qpa-hwcomposer-plugin "

--- a/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher/0001-Rotate-screen-for-harmony.patch
+++ b/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher/0001-Rotate-screen-for-harmony.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Rotate screen for harmony
 
 Upstream-Status: Inappropriate
 ---
- src/compositor/lipstickcompositor.cpp | 2 ++
+ lipstick/src/compositor/lipstickcompositor.cpp | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/src/compositor/lipstickcompositor.cpp b/src/compositor/lipstickcompositor.cpp
+diff --git a/lipstick/src/compositor/lipstickcompositor.cpp b/lipstick/src/compositor/lipstickcompositor.cpp
 index 4dce9d7b..cf5a796e 100644
---- a/src/compositor/lipstickcompositor.cpp
-+++ b/src/compositor/lipstickcompositor.cpp
+--- a/lipstick/src/compositor/lipstickcompositor.cpp
++++ b/lipstick/src/compositor/lipstickcompositor.cpp
 @@ -397,6 +397,8 @@ void LipstickCompositor::initialize()
      QDBusMessage message = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, MCE_DISPLAY_LPM_SET_SUPPORTED);
      message.setArguments(QVariantList() << ambientSupported());

--- a/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher_%.bbappend
+++ b/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher_%.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS:prepend:harmony := "${THISDIR}/asteroid-launcher:"
 SRC_URI:append:harmony = " file://0001-compositor-Fix-new-window-animation-on-screen-rotate.patch"
+SRC_URI:append:harmony = " file://0001-Rotate-screen-for-harmony.patch"

--- a/meta-mtk6580/recipes-nemomobile/lipstick/lipstick_%.bbappend
+++ b/meta-mtk6580/recipes-nemomobile/lipstick/lipstick_%.bbappend
@@ -1,5 +1,0 @@
-RDEPENDS:${PN}:append:harmony = " qt6-qpa-hwcomposer-plugin "
-RDEPENDS:${PN}:append:inharmony = " qt6-qpa-hwcomposer-plugin "
-
-FILESEXTRAPATHS:prepend:harmony := "${THISDIR}/lipstick:"
-SRC_URI:append:harmony = " file://0001-Rotate-screen-for-harmony.patch"

--- a/meta-narwhal/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-narwhal/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:narwhal = " qt6-qpa-hwcomposer-plugin "

--- a/meta-nemo/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-nemo/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:nemo = " qt6-qpa-hwcomposer-plugin "

--- a/meta-pike/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-pike/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:pike = " qt6-qpa-hwcomposer-plugin "

--- a/meta-ray/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-ray/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,2 +1,0 @@
-RDEPENDS:${PN}:append:ray = " qt6-qpa-hwcomposer-plugin "
-RDEPENDS:${PN}:append:firefish = " qt6-qpa-hwcomposer-plugin "

--- a/meta-rubyfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-rubyfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:rubyfish = " qt6-qpa-hwcomposer-plugin "

--- a/meta-sawfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-sawfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:sawfish = " qt6-qpa-hwcomposer-plugin "

--- a/meta-skipjack/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-skipjack/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:skipjack = " qt6-qpa-hwcomposer-plugin "

--- a/meta-smelt/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-smelt/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:smelt = " qt6-qpa-hwcomposer-plugin "

--- a/meta-sparrow/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-sparrow/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:sparrow = " qt6-qpa-hwcomposer-plugin "

--- a/meta-sprat/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-sprat/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:sprat = " qt6-qpa-hwcomposer-plugin "

--- a/meta-sturgeon/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-sturgeon/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:sturgeon = " qt6-qpa-hwcomposer-plugin "

--- a/meta-swift/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-swift/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:swift = " qt6-qpa-hwcomposer-plugin "

--- a/meta-tetra/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-tetra/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:tetra = " qt6-qpa-hwcomposer-plugin "

--- a/meta-triggerfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-triggerfish/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:triggerfish = " qt6-qpa-hwcomposer-plugin "

--- a/meta-wren/recipes-nemomobile/lipstick/lipstick_git.bbappend
+++ b/meta-wren/recipes-nemomobile/lipstick/lipstick_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append:wren = " qt6-qpa-hwcomposer-plugin"


### PR DESCRIPTION
lipstick has been merged into the asteroid-launcher repository and its Yocto recipe is gone:

- The 26 identical lipstick bbappends adding qt6-qpa-hwcomposer-plugin to RDEPENDS (plus mtk6580's harmony/inharmony variants) are replaced by a single RDEPENDS:${PN}:append:hybris-machine line in the asteroid-launcher recipe itself; every one of those machines pulls conf/machine/include/hybris-watch.inc which sets that override.
- mtk6580's harmony screen-rotation patch moves into its asteroid-launcher bbappend, with paths rebased under lipstick/.