### PR TITLE
Rinato: hack kernel version to supress errors.

### DIFF
--- a/meta-rinato/recipes-kernel/linux/linux-rinato/linux-rinato_next.bb
+++ b/meta-rinato/recipes-kernel/linux/linux-rinato/linux-rinato_next.bb
@@ -11,7 +11,7 @@ SRC_URI = " git://git@github.com/casept/linux-samsung-smartwatch.git;protocol=ht
 
 SRCREV = "bf245d6426986d0b24e1d8d2a671726c2f994862"
 
-LINUX_VERSION ?= "next"
+LINUX_VERSION ?= "next.0"
 KERNEL_VERSION_SANITY_SKIP="1"
 
 PV = "${LINUX_VERSION}"


### PR DESCRIPTION
yocto seems to expect KERNEL_VERSION to be in x.y format.