### PR TITLE
Aurora: tolerate missing init_ffs

### DIFF
--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/usb-moded.service
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/usb-moded.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=usb-moded USB gadget controller
+DefaultDependencies=no
+Requires=dbus.socket
+After=local-fs.target dbus.socket
+Conflicts=shutdown.target
+
+[Service]
+Type=dbus
+TimeoutSec=15
+EnvironmentFile=-/var/lib/environment/usb-moded/*.conf
+EnvironmentFile=-/run/usb-moded/*.conf
+ExecStartPre=-/usr/bin/init_ffs
+ExecStartPre=-/bin/mkdir -p /run/systemd/boot-status/
+ExecStartPre=-/bin/touch /run/systemd/boot-status/init-done
+ExecStart=/usr/sbin/usb_moded --systemd --force-syslog $USB_MODED_ARGS
+Restart=always
+ExecReload=/bin/kill -HUP $MAINPID
+BusName=com.meego.usb_moded
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded_%.bbappend
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded_%.bbappend
@@ -63,7 +63,8 @@ FILESEXTRAPATHS:prepend:aurora := "${THISDIR}/usb-moded:"
 #    appsync. Auto-start at basic.target races our adbd-prepare with
 #    usb-moded's configfs_set_function and ends up with adbd holding the
 #    abstract socket "local:5037" without a valid /dev/usb-ffs/adb/ep0.
-SRC_URI:append:aurora = " file://init_gfs \
+SRC_URI:append:aurora = " file://usb_moded.service \
+                          file://init_gfs \
                           file://init_gfs.service \
                           file://aurora-defaults.ini \
                           file://dyn-modes/adb_mode.ini \


### PR DESCRIPTION
I can't actually test this, as I don't have an aurora
This change was previously pushed to meta-asteroid, but seems to have broken usb on all watches post-pie. move here until the rest of usb-moded improves.
