### PR TITLE
aurora-boot-images: strip debug info from vendor kernel modules before packing ramdisk

### DIFF
--- a/meta-aurora/recipes-bsp/aurora-boot-images/aurora-boot-images.bb
+++ b/meta-aurora/recipes-bsp/aurora-boot-images/aurora-boot-images.bb
@@ -44,6 +44,7 @@ DEPENDS = "\
     initramfs-android-image \
     mkbootimg-tools-native \
     dtc-native \
+    clang-native \
 "
 do_compile[depends] += "\
     virtual/kernel:do_compile \
@@ -122,6 +123,19 @@ do_compile() {
         --symvers       "${LINUX_AURORA_SYMVERS}" \
         --static-dir    ${S}/static \
         --out           ${WORKDIR}/vkb_ramdisk
+
+    # ─── Step 2.5: strip debug info from aarch64 kernel modules ───
+    # This recipe runs in an armv7 context but the vendor kernel modules
+    # are aarch64 ELF. The default strip tool silently does nothing on a
+    # foreign ELF target, leaving full debug info in every .ko file.
+    # llvm-strip from clang-native is architecture-agnostic and correctly
+    # strips aarch64 ELF from any build context.
+    LLVM_STRIP=$(find ${STAGING_BINDIR_NATIVE} -name "llvm-strip" | head -1)
+    if [ -z "$LLVM_STRIP" ]; then
+        bbfatal "llvm-strip not found in ${STAGING_BINDIR_NATIVE} -- check clang-native is in DEPENDS"
+    fi
+    find ${WORKDIR}/vkb_ramdisk -name "*.ko" -exec "$LLVM_STRIP" --strip-debug {} \;
+    bbnote "stripped debug info from aarch64 kernel modules"
 
     # ─── Step 3: ramoops DTB. Base = static vkb-base.dtb (stock,
     #            bootloader-approved with qcom,msm-id + qcom,board-id


### PR DESCRIPTION
The recipe runs in an armv7 build context but the vendor kernel modules are aarch64 ELF. The default strip tool silently does nothing on a foreign ELF target, leaving all 141 modules with full debug symbols. wlan.ko alone is 320MB unstripped, causing the compressed ramdisk to reach 150MB against a 64MB partition cap.

Fix by adding an llvm-strip pass between ramdisk assembly and cpio packing. llvm-strip from clang-native is architecture-agnostic and correctly handles aarch64 ELF from any build context. Drops the ramdisk from 150MB to 7.5MB.

Tested: full aurora image build confirmed passing with this fix applied.
