### PR TITLE
meta-skipjack: bring up the GPS HAL (gnss@1.0-service)

### DIFF
--- a/meta-skipjack/recipes-android/android-init/android-init/init.rc
+++ b/meta-skipjack/recipes-android/android-init/android-init/init.rc
@@ -12,10 +12,18 @@ on init
     restorecon_recursive /persist
 
     mkdir /data/
+    mkdir /data/system
+    mkdir /data/system/gps
 
     setprop init.svc.bluetooth running
 
+    chown system root /dev/hwbinder
+    chown system root /dev/vndbinder
+    chmod 0777 /dev/hwbinder
+    chmod 0777 /dev/vndbinder
+
     class_start core
+    class_start hal
 
 service logd /usr/libexec/hal-droid/system/bin/logd
     class core
@@ -57,3 +65,6 @@ service wcnss_service /vendor/bin/wcnss_service
     class core
     user root
     oneshot
+
+service vendor.gnss_service /vendor/bin/hw/android.hardware.gnss@1.0-service
+    class hal

--- a/meta-skipjack/recipes-android/android/android-system-data_skipjack-p.bb
+++ b/meta-skipjack/recipes-android/android/android-system-data_skipjack-p.bb
@@ -2,9 +2,9 @@ inherit gettext
 
 SUMMARY = "Downloads the TicWatch C2+ system folders and installs them for libhybris"
 LICENSE = "CLOSED"
-SRC_URI = "https://dl.dropboxusercontent.com/scl/fi/40t4h39rzn4b4o7inc67g/system-skipjack.tar.gz?rlkey=s1pexo5gg82l0jt9tk34mdhgw&dl=0;downloadfilename=system-skipjack.tar.gz"
-SRC_URI[md5sum] = "fc4c198e3b6c3594bb53a411c38a81d3"
-SRC_URI[sha256sum] = "3d0a4a902680f3226dc67263477642a2c674dd5ced41545182416ee5103d456d"
+SRC_URI = "https://mosushi.de/misc/system-skipjack.tar.gz"
+SRC_URI[md5sum] = "4a381613e21a029225aed624b70dc97e"
+SRC_URI[sha256sum] = "3e854b7cc1a9caa1209c463f6f0ee7582dbd6d9537a180e55899dd4e4fb97d28"
 PV = "pie"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
## What

skipjack had no GPS at the HAL level. Its init never started the vendor HIDL
class, so the whole class hal layer was dark, and the gnss service files were
missing from the system image entirely.

This brings up the GPS HAL in two parts:

1. Ship the gnss@1.0-service binary and its config files in the system tarball.
   They live on the /vendor partition, which the /system-only factory dump
   never captured.
2. In init.rc: add the hwbinder/vndbinder permissions and class_start hal, and
   define gnss@1.0-service inline. This init does not import /vendor/etc/init,
   so class_start hal has nothing to start otherwise. It runs as root, see the
   open question below.

## Tested

Hardware-tested on skipjack from a clean image build:

- init.svc.vendor.gnss_service reaches running
- gnss@1.0-service starts via class_start hal
- /init.rc installs root:root 0644, init does not skip it as insecure

## Scope

This is the HAL layer only. It brings the gnss service up on hwbinder. An actual
position fix additionally needs the location consumer (geoclue-hybris), which
hits a separate, shared, fleet-wide setuid blocker that is out of scope here.

## Open question

The gnss service runs as root. The vendor .rc wants user gps, but no gps user
exists on the rootfs. Running as root is the validated, working choice. If you
would rather add a gps user first, say so.

## Disclosure

This change was machine-authored end to end. I did not review the internals
myself, so you are reviewing machine output. Please review it carefully.

Disclosure: LLMGD-0 · origin O0 (machine-authored and machine-decided; agent-tested on hardware, not reviewed by the human maintainer)
LLMGD: v0.2; assurance=A0; flags=; origin_headline=O0; scope=code+recipe+build; graded-by=self-report; retrieval=author-side

https://github.com/moWerk/llmgd-specs
