### PR TITLE
libhybris: drop per-device warning suppressions

### DIFF
--- a/meta-anthias/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-anthias/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `anthias`
-CFLAGS:append:anthias = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-bass/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-bass/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,3 +1,1 @@
 SRC_URI:append:bass = " file://0001-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
-# native_handle_clone is not declared on android-headers provider for `bass`
-CFLAGS:append:bass = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-dory/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-dory/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `dory`
-CFLAGS:append:dory = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-lenok/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-lenok/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,3 +1,1 @@
 SRC_URI:append:lenok = " file://0001-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
-# native_handle_clone is not declared on android-headers provider for `lenok`
-CFLAGS:append:lenok = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-minnow/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-minnow/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,3 +1,1 @@
 SRC_URI:append:minnow = " file://0001-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
-# native_handle_clone is not declared on android-headers provider for `minnow`
-CFLAGS:append:minnow = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-mtk6580/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-mtk6580/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,4 +1,0 @@
-# native_handle_clone is not declared in headers and gps_callback uses pointer cast with incompatible types.
-CFLAGS:append:harmony = " -Wno-implicit-function-declaration -Wno-int-conversion -Wno-incompatible-pointer-types"
-CFLAGS:append:inharmony = " -Wno-implicit-function-declaration -Wno-int-conversion  -Wno-incompatible-pointer-types"
-

--- a/meta-nemo/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-nemo/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,3 +1,1 @@
 SRC_URI:append:nemo = " file://0001-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
-# native_handle_clone is not declared on android-headers provider for `nemo`
-CFLAGS:append:nemo = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-sawfish/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-sawfish/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `sawfish`
-CFLAGS:append:sawfish = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-smelt/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-smelt/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `smelt`
-CFLAGS:append:smelt = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-sparrow/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-sparrow/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `sparrow`
-CFLAGS:append:sparrow = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-sprat/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-sprat/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `sprat`
-CFLAGS:append:sprat = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-sturgeon/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-sturgeon/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,3 +1,1 @@
 SRC_URI:append:sturgeon = " file://0001-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
-# native_handle_clone is not declared on android-headers provider for `sturgeon`
-CFLAGS:append:sturgeon = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-swift/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-swift/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `swift`
-CFLAGS:append:swift = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-tetra/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-tetra/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `tetra`
-CFLAGS:append:tetra = " -Wno-implicit-function-declaration -Wno-int-conversion"

--- a/meta-wren/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-wren/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,2 +1,0 @@
-# native_handle_clone is not declared on android-headers provider for `wren`
-CFLAGS:append:wren = " -Wno-implicit-function-declaration -Wno-int-conversion"


### PR DESCRIPTION
The -Wno-implicit-function-declaration / -Wno-int-conversion / -Wno-incompatible-pointer-types flags are now applied to every machine by meta-asteroid's libhybris bbappend. Drop them from the per-device bbappends: the ones whose only content was these flags are removed entirely, the rest keep just their SRC_URI patch lines.