### PR TITLE
mtk6580: asteroid-launcher: Refresh the compositor patch

### DIFF
--- a/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher/0001-compositor-Fix-new-window-animation-on-screen-rotate.patch
+++ b/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher/0001-compositor-Fix-new-window-animation-on-screen-rotate.patch
@@ -13,13 +13,12 @@ Upstream-Status: Inappropriate
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/qml/compositor/compositor.qml b/src/qml/compositor/compositor.qml
-index 4e046d0..13c3672 100644
 --- a/src/qml/compositor/compositor.qml
 +++ b/src/qml/compositor/compositor.qml
-@@ -242,7 +242,10 @@ Item {
-                 }
-                 appLayer.ready = false
-                 w.smoothBorders = true
+@@ -244,7 +244,10 @@
+                 w.smoothBorders = Qt.binding(function() {
+                     return gestureArea.active || appLayer.opacity < 1.0 || !appLayer.ready
+                 })
 -                w.x = width
 +                if(root.rotation == 0)
 +                    w.x = width


### PR DESCRIPTION
asteroid-launcher turned w.smoothBorders into a Qt.binding, so the hunk's context no longer matched and do_patch failed:

    Hunk #1 FAILED at 242.

The change itself is still needed - the rotation-aware w.x is not upstream and root.rotation still exists - so refresh the context rather than drop it.