### PR TITLE
meta-aurora: adb and ssh over one USB gadget (NCM)

### DIFF
--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-network
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-network
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Add the NCM function to aurora's USB gadget, giving ssh-over-USB alongside adb.
+#
+# usb-moded's udev watch does not survive startup here, so it never selects a
+# mode: it neither starts adbd nor sets up a network function, and its
+# developer_mode asks for rndis, which these kernels do not provide. ncm.0 is
+# available, and linking it next to ffs.adb yields one composite gadget carrying
+# both channels at once.
+set -u
+
+G=/config/usb_gadget/g1
+ADDR="${AURORA_USB_ADDR:-192.168.42.2/24}"
+LOGF=/var/log/aurora-usb-network.log
+# usb-moded rewrites configs/b.1 while starting, so give it time to finish.
+SETTLE="${AURORA_USB_SETTLE:-8}"
+
+log() {
+    echo "aurora-usb-network: $1"
+    echo "$(cut -d. -f1 /proc/uptime)s $1" >> "$LOGF" 2>/dev/null || true
+}
+
+# MAC derived from the device serial, so the IPv6 link-local is stable per watch
+# and a host can reach it at fe80::...%iface without assigning addresses. 0x02
+# marks it locally administered and unicast.
+stable_mac() {
+    dsn=""
+    [ -r /sys/firmware/devicetree/base/chosen/config/dsn ] && \
+        dsn="$(tr -d '\0' < /sys/firmware/devicetree/base/chosen/config/dsn)"
+    [ -n "$dsn" ] || dsn="$(cat /etc/hostname 2>/dev/null)"
+    [ -n "$dsn" ] || dsn="asteroid"
+    h=$(printf '%s' "$dsn" | md5sum | cut -c1-10)
+    printf '02:%s:%s:%s:%s:%s\n' \
+        "$(printf '%s' "$h" | cut -c1-2)" "$(printf '%s' "$h" | cut -c3-4)" \
+        "$(printf '%s' "$h" | cut -c5-6)" "$(printf '%s' "$h" | cut -c7-8)" \
+        "$(printf '%s' "$h" | cut -c9-10)"
+}
+
+# dev_addr only reaches the netdev while the function is unbound and its
+# interface is down, hence the call sites below.
+pin_mac() {
+    want=$(stable_mac)
+    cur=$(tr -d '\0' < "$G/functions/ncm.0/dev_addr" 2>/dev/null)
+    [ "$cur" = "$want" ] && return 0
+    echo "$want" > "$G/functions/ncm.0/dev_addr" 2>/dev/null \
+        && log "dev_addr=$want" \
+        || log "could not set dev_addr; link-local will vary per boot"
+}
+
+# android-tools-adbd is preset-disabled and started by usb-moded's appsync,
+# which does not run here. Starting it late is safe: adbd pulls adbd-prepare in
+# itself, so FunctionFS is mounted before descriptors are written.
+ensure_adb() {
+    if [ ! -d "$G/functions/ffs.adb" ]; then
+        mkdir "$G/functions/ffs.adb" 2>/dev/null || log "could not create ffs.adb"
+    fi
+    systemctl is-active --quiet android-tools-adbd \
+        || systemctl start android-tools-adbd 2>/dev/null \
+        || log "adbd start failed"
+
+    # ep1 appears once FunctionFS is active; binding the UDC before that fails.
+    i=0
+    while [ ! -e /dev/usb-ffs/adb/ep1 ] && [ "$i" -lt 100 ]; do
+        i=$((i + 1)); sleep 0.1
+    done
+    [ -e /dev/usb-ffs/adb/ep1 ] || log "ep1 absent; adb will not work"
+
+    [ -e "$G/configs/b.1/ffs.adb" ] || \
+        ln -sf "$G/functions/ffs.adb" "$G/configs/b.1/ffs.adb" 2>/dev/null || \
+        log "could not link ffs.adb"
+}
+
+[ -d "$G" ] || { log "$G missing"; exit 1; }
+
+if [ ! -d "$G/functions/ncm.0" ]; then
+    # mkdir failing here means the kernel has no NCM function.
+    mkdir "$G/functions/ncm.0" 2>/dev/null || { log "no NCM support"; exit 0; }
+    pin_mac
+fi
+
+ensure_adb
+
+[ -e /sys/class/net/usb0 ] && ip link set usb0 down 2>/dev/null
+pin_mac
+
+if [ -e "$G/configs/b.1/ncm.0" ]; then
+    log "ncm.0 already linked"
+else
+    U=$(ls /sys/class/udc 2>/dev/null | head -1)
+    [ -n "$U" ] || { log "no UDC"; exit 1; }
+
+    # Adding a function requires unbinding, which briefly drops adb. Retry and
+    # confirm the link survived: usb-moded may still rewrite configs/b.1.
+    sleep "$SETTLE"
+    attempt=0
+    while [ "$attempt" -lt 5 ]; do
+        attempt=$((attempt + 1))
+        echo "" > "$G/UDC" 2>/dev/null
+        sleep 1
+        ln -sf "$G/functions/ncm.0" "$G/configs/b.1/ncm.0" 2>/dev/null
+        sleep 1
+        echo "$U" > "$G/UDC" 2>/dev/null
+        sleep 3
+        if [ -e "$G/configs/b.1/ncm.0" ] && [ -n "$(cat "$G/UDC" 2>/dev/null)" ]; then
+            log "ncm.0 linked (attempt $attempt)"
+            break
+        fi
+        log "attempt $attempt did not hold; retrying"
+        sleep 3
+    done
+    if [ ! -e "$G/configs/b.1/ncm.0" ]; then
+        log "could not keep ncm.0 linked"
+        echo "$U" > "$G/UDC" 2>/dev/null
+        exit 1
+    fi
+fi
+
+i=0
+while [ ! -e /sys/class/net/usb0 ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
+[ -e /sys/class/net/usb0 ] || { log "usb0 did not appear"; exit 1; }
+
+ip link set usb0 up 2>/dev/null
+ip addr add "$ADDR" dev usb0 2>/dev/null || true
+log "usb0 $(ip -4 addr show usb0 2>/dev/null | grep -o 'inet [0-9./]*' | head -1)"

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-network.service
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-network.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Aurora: USB network (NCM) for ssh-over-USB
+# Needs the g1 skeleton in place. Deliberately not ordered against
+# android-tools-adbd: it is preset-disabled and may never be started by
+# usb-moded's appsync, so this unit starts it instead.
+After=init_gfs.service usb-moded.service
+Wants=init_gfs.service adbd-prepare.service
+Before=aurora-usb-reenumerate.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/aurora-usb-network
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-reenumerate
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-reenumerate
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Force one USB re-enumeration once the real gadget is up.
+#
+# The host enumerates the initramfs composition early in boot; init_gfs then
+# stages g1 and the adb/network functions follow. Nothing signals that swap, so
+# the host keeps addressing a composition that no longer exists. Toggling
+# soft_connect drops and re-asserts the D+ pull-up, and the host re-enumerates.
+#
+# One-shot by design: a re-enumeration interrupts any live adb session.
+set -u
+
+G=/config/usb_gadget/g1
+WAIT_MAX=60
+LOGF=/var/log/aurora-usb-reenumerate.log
+
+log() {
+    echo "aurora-usb-reenumerate: $1"
+    echo "$(cut -d. -f1 /proc/uptime)s $1" >> "$LOGF" 2>/dev/null || true
+}
+
+udc_name() { ls /sys/class/udc 2>/dev/null | head -n 1; }
+
+# Ready means bound and carrying adb; re-enumerating an incomplete gadget only
+# presents the host with another one it cannot use.
+gadget_ready() {
+    u=$(udc_name)
+    [ -n "$u" ] || return 1
+    [ -n "$(cat "$G/UDC" 2>/dev/null)" ] || return 1
+    [ -e "$G/configs/b.1/ffs.adb" ] || return 1
+    return 0
+}
+
+i=0
+while [ "$i" -lt "$WAIT_MAX" ]; do
+    gadget_ready && break
+    i=$((i + 1))
+    sleep 1
+done
+
+gadget_ready || { log "gadget not ready after ${WAIT_MAX}s"; exit 0; }
+
+U=$(udc_name)
+F="/sys/class/udc/$U/soft_connect"
+[ -e "$F" ] || { log "no soft_connect node"; exit 0; }
+
+# Accept either the string or numeric form, depending on kernel.
+{ echo disconnect > "$F" 2>/dev/null || echo 0 > "$F" 2>/dev/null; } \
+    || { log "could not disconnect"; exit 0; }
+sleep 2
+{ echo connect > "$F" 2>/dev/null || echo 1 > "$F" 2>/dev/null; } \
+    || log "could not reconnect; USB may be down"
+
+sleep 3
+log "re-enumerated, udc state=$(cat "/sys/class/udc/$U/state" 2>/dev/null)"

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-reenumerate.service
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/aurora-usb-reenumerate.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Aurora: re-enumerate USB once the gadget is complete
+# Runs after the gadget is assembled; the script waits for a bound gadget
+# carrying adb and does nothing if that never happens.
+After=init_gfs.service usb-moded.service aurora-usb-network.service
+Wants=init_gfs.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/aurora-usb-reenumerate
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/init_gfs
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded/init_gfs
@@ -10,7 +10,21 @@
 # ffs.adb just makes for a race we cannot win. usb-moded is the sole writer of
 # g1/functions/* and configs/b.1/<links>.
 
-serial="$(cat /proc/cmdline | sed 's/.*androidboot.serialno=//' | sed 's/ .*//')"
+# USB serial number, from the device tree.
+#
+# aurora's cmdline carries no androidboot.serialno= key, so a plain sed
+# substitution would pass the line through unchanged and yield the first cmdline
+# token. The serial lives in chosen/config/dsn; the cmdline is only consulted
+# when the key is actually present.
+serial=""
+if [ -r /sys/firmware/devicetree/base/chosen/config/dsn ]; then
+    serial="$(tr -d '\0' < /sys/firmware/devicetree/base/chosen/config/dsn)"
+fi
+if [ -z "$serial" ] && grep -q "androidboot.serialno=" /proc/cmdline; then
+    serial="$(sed 's/.*androidboot.serialno=//; s/ .*//' /proc/cmdline)"
+fi
+# An empty serialnumber breaks `adb -s` as thoroughly as a wrong one.
+[ -n "$serial" ] || serial="aurora"
 
 # usb-moded reads configfs through /config; mount the kernel's configfs there
 # if not already mounted.

--- a/meta-aurora/recipes-nemomobile/usb-moded/usb-moded_%.bbappend
+++ b/meta-aurora/recipes-nemomobile/usb-moded/usb-moded_%.bbappend
@@ -71,6 +71,10 @@ SRC_URI:append:aurora = " file://usb-moded.service \
                           file://run/adb-startserver.ini \
                           file://adbd-prepare.service \
                           file://10-aurora-android-tools.preset \
+                          file://aurora-usb-network \
+                          file://aurora-usb-network.service \
+                          file://aurora-usb-reenumerate \
+                          file://aurora-usb-reenumerate.service \
                           file://0001-Wait-for-FunctionFS-FFS_ACTIVE-before-configfs_set_u.patch"
 
 do_install:append:aurora() {
@@ -111,9 +115,31 @@ do_install:append:aurora() {
         ${D}/etc/usb-moded/dyn-modes/adb_mode.ini
     install -m 0644 ${UNPACKDIR}/run/adb-startserver.ini \
         ${D}/etc/usb-moded/run/adb-startserver.ini
+
+    # NCM gives ssh-over-USB alongside adb; the re-enumerate one-shot makes the
+    # host pick up the finished gadget. See the script headers.
+    install -m 0755 ${UNPACKDIR}/aurora-usb-network ${D}/usr/bin/aurora-usb-network
+    install -m 0644 ${UNPACKDIR}/aurora-usb-network.service \
+        ${D}${systemd_unitdir}/system/aurora-usb-network.service
+    install -d ${D}${systemd_unitdir}/system/multi-user.target.wants
+    ln -sf ../aurora-usb-network.service \
+        ${D}${systemd_unitdir}/system/multi-user.target.wants/aurora-usb-network.service
+
+    install -m 0755 ${UNPACKDIR}/aurora-usb-reenumerate ${D}/usr/bin/aurora-usb-reenumerate
+    install -m 0644 ${UNPACKDIR}/aurora-usb-reenumerate.service \
+        ${D}${systemd_unitdir}/system/aurora-usb-reenumerate.service
+    install -d ${D}${systemd_unitdir}/system/multi-user.target.wants
+    ln -sf ../aurora-usb-reenumerate.service \
+        ${D}${systemd_unitdir}/system/multi-user.target.wants/aurora-usb-reenumerate.service
 }
 
 FILES:${PN}:append:aurora = " ${systemd_unitdir}/system/init_gfs.service \
                               ${systemd_unitdir}/system/sysinit.target.wants/init_gfs.service \
                               ${systemd_unitdir}/system/adbd-prepare.service \
-                              ${systemd_unitdir}/system-preset/10-aurora-android-tools.preset"
+                              ${systemd_unitdir}/system-preset/10-aurora-android-tools.preset \
+                              /usr/bin/aurora-usb-network \
+                              ${systemd_unitdir}/system/aurora-usb-network.service \
+                              ${systemd_unitdir}/system/multi-user.target.wants/aurora-usb-network.service \
+                              /usr/bin/aurora-usb-reenumerate \
+                              ${systemd_unitdir}/system/aurora-usb-reenumerate.service \
+                              ${systemd_unitdir}/system/multi-user.target.wants/aurora-usb-reenumerate.service"


### PR DESCRIPTION
aurora only ever offered adb, and unreliably; ssh-over-USB never worked.

Both come from usb-moded, whose udev watch dies at startup here, so it never
selects a mode. adb depended on its appsync and came up only on some boots, and
developer_mode asks for rndis, which these kernels do not provide
(CONFIG_USB_CONFIGFS_RNDIS unset).

This links ncm.0 alongside ffs.adb: one composite gadget carrying adb and
network at the same time, so nothing switches between them. sshd needs no
change. A second commit fixes the gadget serial, which was being taken from the
wrong place and made `adb -s <serial>` fail against a healthy watch.

Worth noting for testing: RNDIS has never been usable on macOS, while CDC-NCM is
supported there natively - kido wanted to try exactly this.

Verified on aurora across reboots: adb and ssh both up unaided, correct serial,
and a link-local that is identical on every boot (the NCM MAC is derived from
the device tree DSN), so a host reaches the watch at fe80::...%iface with no
address assignment and no root.

Only meta-aurora is touched. The same approach applies to sol (its kernel has
CONFIG_USB_CONFIGFS_NCM=y and no rndis) but that is a separate PR. The 4.9-era
watches (beluga, rubyfish) have no configfs gadget at all, so this does not
apply to them.

This was executed by an LLM under my direction. I have fully tested the changes and pre-reviewed the code.
