### PR TITLE
sawfish: publish Python 3 in the opkg feed

### DIFF
--- a/meta-sawfish/conf/machine/sawfish.conf
+++ b/meta-sawfish/conf/machine/sawfish.conf
@@ -18,3 +18,7 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-sawfish"
 PREFERRED_VERSION_linux = "3.10+nougat"
 
 IMAGE_INSTALL += "sensorfw-hybris-hal-plugins brcm-patchram-plus iproute2 wpa-supplicant underclock asteroid-hrm"
+
+# Build the CPython runtime into the sawfish opkg feed without adding it to the
+# default image. This produces armv7vehf-neon packages for on-device installs.
+PACKAGE_FEED:append = " python3"


### PR DESCRIPTION
Closes AsteroidOS/meta-asteroid#326.

Adds the existing OpenEmbedded `python3` target package to `PACKAGE_FEED` only for sawfish. AsteroidOS’s package-feed task will therefore build and index the CPython runtime and its split runtime dependencies for `armv7vehf-neon`, while the default image remains unchanged.

Validation: checked this configuration against the pinned `walnascar` OpenEmbedded Python recipe, which provides the `python3` runtime package, and ran `git diff --check`.