### PR TITLE
hoki: wlan: working WiFi driver from source

### DIFF
--- a/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki/wlan-firmware-hoki.service
+++ b/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki/wlan-firmware-hoki.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable pronto WLAN firmware and load the wlan module on hoki
+After=android-init.service
+Before=connman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/wlan-firmware-hoki.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki/wlan-firmware-hoki.sh
+++ b/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki/wlan-firmware-hoki.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Symlink stock vendor WCNSS firmware/calibration data into the path the
+# out-of-tree pronto WLAN driver actually looks under, power up WCNSS by
+# opening (not writing) /dev/wcnss_wlan, then load the driver.
+# See https://github.com/AsteroidOS/meta-smartwatch/issues/224
+
+mkdir -p /lib/firmware/wlan/prima
+
+for f in WCNSS_qcom_cfg.ini WCNSS_qcom_wlan_nv.bin WCNSS_wlan_dictionary.dat; do
+	if [ ! -e "/lib/firmware/wlan/prima/$f" ]; then
+		ln -s "/vendor/firmware/wlan/prima/$f" "/lib/firmware/wlan/prima/$f"
+	fi
+done
+
+# Opening this device node is what actually powers WCNSS up; the write
+# itself is expected to fail and is not an error.
+echo 1 > /dev/wcnss_wlan 2>/dev/null || true
+
+modprobe wlan

--- a/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki_1.0.bb
+++ b/meta-hoki/recipes-core/wlan-firmware-hoki/wlan-firmware-hoki_1.0.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Symlinks stock vendor WCNSS firmware and loads the pronto WLAN driver on hoki"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://wlan-firmware-hoki.sh;beginline=1;endline=2;md5=930f306dfea099b7fea2177393af6bd6"
+PR = "r0"
+
+SRC_URI = "file://wlan-firmware-hoki.service \
+           file://wlan-firmware-hoki.sh \
+           "
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "hoki"
+
+RDEPENDS:${PN} = "kernel-module-wlan"
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 wlan-firmware-hoki.sh ${D}${bindir}
+
+    install -d ${D}/etc/systemd/system/multi-user.target.wants/
+    cp wlan-firmware-hoki.service ${D}/etc/systemd/system/
+    ln -s ../wlan-firmware-hoki.service ${D}/etc/systemd/system/multi-user.target.wants/wlan-firmware-hoki.service
+}
+
+FILES:${PN} += "/etc/systemd/system/"

--- a/meta-hoki/recipes-kernel/linux/linux-hoki/wakelock.h
+++ b/meta-hoki/recipes-kernel/linux/linux-hoki/wakelock.h
@@ -1,0 +1,3 @@
+/* Empty stub. This header was removed from mainline Linux (replaced by the
+ * wakeup_source API) but the vendor pronto WLAN driver still #includes it.
+ * See https://github.com/AsteroidOS/meta-smartwatch/issues/224 */

--- a/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
+++ b/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://github.com/fossil-engineering/kernel-msm-fossil-cw;branch=fossi
            file://0004-usb-hcd-Handle-when-host-mode-isn-t-available.patch \
            file://0005-initramfs-Don-t-skip-initramfs.patch \
            file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           file://wakelock.h \
            "
 
 SRCREV = "c0b4c201f2d5a641defe19958a9b4c16f40d866b"
@@ -28,8 +29,14 @@ LINUX_VERSION_EXTENSION = ""
 PE = "1"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
+# hoki's vendor kernel is old enough to predate the wakeup_source API
+# transition; several drivers (notably the out-of-tree WLAN driver, see
+# https://github.com/AsteroidOS/meta-smartwatch/issues/224) still #include
+# include/linux/wakelock.h, which was removed from mainline. Provide an
+# empty stub so those drivers build.
 do_configure:prepend() {
     install -m 644 -D ${UNPACKDIR}/defconfig ${WORKDIR}/defconfig
+    install -m 644 -D ${UNPACKDIR}/wakelock.h ${S}/include/linux/wakelock.h
 }
 
 do_install:append() {

--- a/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki/0001-hdd_process_bt_sco_profile-fix-use-of-adapter-before.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki/0001-hdd_process_bt_sco_profile-fix-use-of-adapter-before.patch
@@ -1,0 +1,31 @@
+From 749c0d6d61aaf3e2e9f655cd1af980c0d06efc6e Mon Sep 17 00:00:00 2001
+From: pettcomputers <chris@pettcomputers.com>
+Date: Sun, 30 Aug 2026 09:48:28 -0500
+Subject: [PATCH] hdd_process_bt_sco_profile: fix use of adapter before
+ assignment
+
+---
+ CORE/HDD/src/wlan_hdd_main.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/CORE/HDD/src/wlan_hdd_main.c b/CORE/HDD/src/wlan_hdd_main.c
+index 91368f1..a80b1f4 100644
+--- a/CORE/HDD/src/wlan_hdd_main.c
++++ b/CORE/HDD/src/wlan_hdd_main.c
+@@ -3974,6 +3974,13 @@ int hdd_process_bt_sco_profile(hdd_context_t *hdd_ctx,
+ 		return -EINVAL;
+ 	}
+ 
++	adapter = hdd_get_adapter(hdd_ctx, WLAN_HDD_INFRA_STATION);
++	if (!adapter) {
++		hddLog(VOS_TRACE_LEVEL_ERROR,
++		       "%s: No station adapter, skipping bt profile", __func__);
++		return -EINVAL;
++	}
++
+ 	INIT_COMPLETION(hdd_ctx->sw_pta_comp);
+ 
+ 	hal_status = sme_sw_pta_req(hdd_ctx->hHal, hdd_sw_pta_resp_callback,
+-- 
+2.51.1
+

--- a/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki/0002-Makefile-quote-CC-LD-AR-OBJCOPY-STRIP-in-nested-make.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki/0002-Makefile-quote-CC-LD-AR-OBJCOPY-STRIP-in-nested-make.patch
@@ -1,0 +1,26 @@
+From c597ca249a4ec61fd8ceddd9474eda6e6717535c Mon Sep 17 00:00:00 2001
+From: pettcomputers <chris@pettcomputers.com>
+Date: Sun, 30 Aug 2026 10:10:18 -0500
+Subject: [PATCH] Makefile: quote CC/LD/AR/OBJCOPY/STRIP in nested make
+ invocation
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d5c94f0..c644d01 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,7 @@ KBUILD_OPTIONS += MODNAME=wlan
+ 
+ all::
+ 	$(MAKE) -C $(KERNEL_SOURCE) $(KBUILD_OPTIONS) $(EXTRA_CFLAGS) ARCH=$(ARCH) \
+-		SUBDIRS=$(CURDIR) CC=${CC} modules
++		SUBDIRS=$(CURDIR) CC="$(CC)" LD="$(LD)" AR="$(AR)" OBJCOPY="$(OBJCOPY)" STRIP="$(STRIP)" modules
+ 
+ modules_install:
+ 	$(MAKE) INSTALL_MOD_STRIP=1 -C $(KERNEL_SRC) M=$(shell pwd) modules_install
+-- 
+2.51.1
+

--- a/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki_git.bb
+++ b/meta-hoki/recipes-kernel/modules/linux-wlan-modules-hoki_git.bb
@@ -1,0 +1,27 @@
+SUMMARY = "WLAN (Prima/pronto) kernel module for hoki"
+DESCRIPTION = "Out-of-tree Qualcomm WCNSS/pronto WLAN driver for hoki (SDA429W, msm8937), \
+built from the LA.UM.10.6.2.r1-02500-89xx.0 prima tree with a fix for a real \
+use-before-assignment bug in hdd_process_bt_sco_profile() that oopses the kernel \
+whenever Bluetooth is active while the module loads. \
+See https://github.com/AsteroidOS/meta-smartwatch/issues/224"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://CORE/HDD/src/wlan_hdd_main.c;beginline=1;endline=13;md5=7e85947c06d7ceca827c1a3ca1182f78"
+COMPATIBLE_MACHINE = "hoki"
+
+inherit module kernel-module-split
+
+SRC_URI = "git://github.com/Dev-msm8953/vendor_qcom_opensource_wlan_prima;protocol=https;branch=LA.UM.10.6.2.r1-02500-89xx.0 \
+           file://0001-hdd_process_bt_sco_profile-fix-use-of-adapter-before.patch \
+           file://0002-Makefile-quote-CC-LD-AR-OBJCOPY-STRIP-in-nested-make.patch \
+           "
+SRCREV = "3401b53"
+LINUX_VERSION ?= "4.14"
+PV = "${LINUX_VERSION}+git"
+S = "${WORKDIR}/git"
+B = "${S}"
+
+DEPENDS = "virtual/kernel"
+
+EXTRA_OEMAKE = " KERNEL_SRC="${STAGING_KERNEL_DIR}" KERNEL_SOURCE="${STAGING_KERNEL_DIR}" M="${S}" CONFIG_PRONTO_WLAN=m WLAN_ROOT="${S}" MODNAME=wlan"
+
+RPROVIDES:${PN} += "kernel-module-wlan"


### PR DESCRIPTION
## hoki: working WiFi driver from source

Fixes #224.

Full disclosure: I used Claude Code to help me dig through the kernel/driver source and work through this — I'm not a kernel developer by trade, this was a lot of unfamiliar territory. Sharing it back here in case it saves someone else the same digging.

### What this does

Adds a complete, from-source WLAN driver build for hoki (Skagen Falster Gen 6 / Fossil Gen 6 platform family), plus the firmware/boot wiring to bring it up automatically. Confirmed working end to end: real DHCP lease, 0% packet loss, survives a cold reboot with no manual steps, Bluetooth active the whole time with no kernel oops.

### Why a from-source build

The stock `/vendor/lib/modules/wlan.ko` shipped on the device fails to load against our kernel build (`vermagic` mismatch — it was built against Fossil's own `4.14.206-perf+` kernel, not our from-scratch OE build). Has to be compiled from source against our actual kernel.

### Files added

- `recipes-kernel/modules/linux-wlan-modules-hoki_git.bb` — builds the driver (`Dev-msm8953/vendor_qcom_opensource_wlan_prima`, branch `LA.UM.10.6.2.r1-02500-89xx.0`) against hoki's kernel. `inherit module kernel-module-split`, `CONFIG_PRONTO_WLAN=m`, `MODNAME=wlan`. Needs both `KERNEL_SRC` and `KERNEL_SOURCE` set to `${STAGING_KERNEL_DIR}` — the vendor Makefile's internal `-C $(KERNEL_SOURCE)` uses a different variable name than the OE convention expects, so both have to be set or the build silently uses the wrong path.
- `recipes-core/wlan-firmware-hoki/wlan-firmware-hoki_1.0.bb` + `.sh` + `.service` — symlinks the three vendor firmware files already present on every hoki (`/vendor/firmware/wlan/prima/{WCNSS_qcom_cfg.ini,WCNSS_qcom_wlan_nv.bin,WCNSS_wlan_dictionary.dat}`) into `/lib/firmware/wlan/prima/`, opens (doesn't write) `/dev/wcnss_wlan` to power up WCNSS, then `modprobe wlan`. The systemd unit is ordered `After=android-init.service` and `Before=connman.service` — this ordering is load-bearing, it's what lets the module come up automatically at boot with zero manual steps.

### Two real driver-source bugs fixed on top of the upstream vendor tree

1. **Kernel oops in `hdd_process_bt_sco_profile()`** (`CORE/HDD/src/wlan_hdd_main.c`) — dereferences `adapter->sessionId` about 40 lines before `adapter` is actually assigned via `hdd_get_adapter()`. Moved the lookup and null check above the first use. This is a genuine upstream Qualcomm bug, confirmed present in their own CAF `LA.UM.10.6.2.c25` branch too — not something introduced by this fork.

2. **Unquoted `$(CC)` in the driver's top-level Makefile** — it re-invokes `$(MAKE) -C $(KERNEL_SOURCE) ... CC=${CC} ... modules` without quoting `$(CC)`. Our OE build's `CC` is a compound value with embedded flags (`arm-oe-linux-gnueabi-gcc -fuse-ld=bfd -fcanon-prefix-map ...`), and the unquoted re-invocation lets GNU Make word-split it, which breaks the build entirely (`No rule to make target 'use-ld=bfd'`). Fixed by quoting `CC="$(CC)" LD="$(LD)" AR="$(AR)" OBJCOPY="$(OBJCOPY)" STRIP="$(STRIP)"` in the `all::` target. (Tried working around this with `EXTRA_OEMAKE` CC overrides first — doesn't work, since `module.bbclass`'s own CC assignment comes after `EXTRA_OEMAKE`'s on the command line and GNU Make uses the last assignment. Had to fix the actual Makefile.)

3. **Missing `include/linux/wakelock.h`** — removed from mainline Linux, replaced by the wakeup_source API, but this driver still includes it in several files. Added an empty stub, installed via a small patch to `linux-hoki_p.bb`'s existing `do_configure:prepend()` (it already installs `defconfig` the same way, so this just extends that step).

### Testing

Confirmed via direct device testing, twice — once live, once after a full cold reboot:

- `wlan.ko` loads cleanly with Bluetooth active the entire time, zero kernel oops — directly validates fix #1 against the exact scenario that used to crash the kernel.
- Real hardware MAC address derived (genuine Qualcomm OUI, not a placeholder).
- Connects to a real WPA2 network, gets a real DHCP lease, full routing table, 0% packet loss pinging both the gateway and 1.1.1.1.
- Cold reboot: everything comes back automatically with zero manual steps — same IP re-leased, ping still 0% loss.

### Known gap

`wlan_mac.bin` (optional custom-MAC-override firmware) isn't symlinked in — harmless, the driver falls back to a real generated MAC. Shows up as a non-fatal firmware timeout in dmesg (`firmware wlan!prima!wlan_mac.bin: ... timeout: rc = -2`), doesn't affect connectivity at all. Left it out since it's cosmetic and didn't want to scope-creep the PR.

Happy to adjust anything about the recipe structure if it doesn't match how you'd rather see this organized — this is my first contribution here.
