### PR TITLE
hoki: gnss: symlink real vendor HAL service, enable NTP AGPS assistance

### DIFF
--- a/meta-hoki/recipes-core/gnss-service-hoki/gnss-service-hoki_1.0.bb
+++ b/meta-hoki/recipes-core/gnss-service-hoki/gnss-service-hoki_1.0.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "Symlinks the real vendor GNSS HAL binary to the filename AsteroidOS's \
+hal-droid init compat layer actually looks for, and enables NTP-based AGPS \
+assistance data injection over WiFi (this device has no cellular modem for \
+the alternate SUPL assistance path)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://gps_xtra.ini;md5=2dfad6f123b25b9c584cc209770743a2"
+PR = "r0"
+
+SRC_URI = "file://gps_xtra.ini"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "hoki"
+
+do_install() {
+    install -m 0755 -d ${D}${sysconfdir}
+    install -m 0644 gps_xtra.ini ${D}${sysconfdir}/gps_xtra.ini
+}
+
+pkg_postinst:${PN}() {
+    # hal-droid's init .rc parses a service filename without the "-qti"
+    # suffix, but the real vendor binary is only present as
+    # android.hardware.gnss@1.0-service-qti. Symlink so the service
+    # actually starts. See https://github.com/AsteroidOS/meta-smartwatch/issues/252
+    ln -sf android.hardware.gnss@1.0-service-qti $D/vendor/bin/hw/android.hardware.gnss@1.0-service
+}
+
+FILES:${PN} += "${sysconfdir}/gps_xtra.ini"

--- a/meta-hoki/recipes-core/gnss-service-hoki/gps_xtra.ini
+++ b/meta-hoki/recipes-core/gnss-service-hoki/gps_xtra.ini
@@ -1,0 +1,2 @@
+[ntp]
+NTP_FORCE_INJECT=true


### PR DESCRIPTION
## hoki: working GPS, from vendor HAL fix through to a real location fix

Fixes #252.

Full disclosure: I used Claude Code to help me work through this — same as the WiFi PR (#224/its PR), I'm not a kernel developer by trade and this involved a lot of unfamiliar territory (HIDL, D-Bus, ACDB calibration, etc.). Sharing it back here in case it helps someone else.

### What this does

Gets a complete, working GPS location stack on hoki: the vendor GNSS HAL service starts cleanly at boot, `geoclue` reports real position data, and it's been confirmed with an actual moving fix during a drive (13-15 satellites tracked, live-updating coordinates), not just a stationary indoor test.

### Part 1 — vendor GNSS HAL service

The real vendor binary (`android.hardware.gnss@1.0-service-qti`) is present on `/vendor/bin/hw/` and works fine when launched directly. The blocker was that `hal-droid`'s init parses a `.rc` file referencing the service without the `-qti` suffix — a plain filename mismatch, not a missing binary. Fixed with a symlink at first-boot/postinst time:

```
ln -sf android.hardware.gnss@1.0-service-qti /vendor/bin/hw/android.hardware.gnss@1.0-service
```

Confirmed via `journalctl -b` after a cold reboot: clean `starting service 'vendor.gnss_service'` with zero errors, process stays up.

### Part 2 — location-consumer stack (geoclue) — turned out to already be wired up, just broken

I expected to need to add `geoclue` + `geoclue-provider-hybris-binder` myself (that's what Beluga, same msm8937 platform family, uses — plain upstream packages, no device-specific hacks, so it looked like the missing piece). Turns out `recipes-navigation/geoclue/geoclue_%.bbappend` in this tree already has `RDEPENDS on geoclue-provider-hybris-binder` — someone already wired this in at some point, so nothing to add here. The actual blocker was a real bug in the provider itself, not missing wiring.

**Real bug found and fixed** (this part is a separate PR against `meta-asteroid`, not this repo, since `geoclue-provider-hybris.inc` lives there and the bug isn't hoki-specific — see linked PR): `geoclue-provider-hybris-binder`'s init would crash immediately with `qFatal("Failed to register object ...")`. Traced it to `QDBusConnection::lastError()`: `"Using X11 for dbus-daemon autolaunch was disabled at compile time, set your DBUS_SESSION_BUS_ADDRESS instead"`. The binary is installed setuid-root by upstream's own `geoclue-provider-hybris.inc` (`chmod 04755`), and a setuid-root process has real-uid ≠ effective-uid — exactly the condition under which glibc/D-Bus strip environment variables like `DBUS_SESSION_BUS_ADDRESS` as a real, documented security hardening behavior, happening at the dynamic-loader level before `main()` runs. Confirmed the GNSS binder access this binary needs doesn't actually require root on this port — changed the install step from `chmod 04755` to `chmod 0755`. This affects every device using this provider, not just hoki, which is why it's split into its own PR.

```diff
- chmod 04755 ${D}${libexecdir}/geoclue-hybris
+ chmod 0755 ${D}${libexecdir}/geoclue-hybris
```

Confirmed via a real cold reboot: `busctl --user introspect org.freedesktop.Geoclue.Providers.Hybris ...` returns the full expected interface set (`Position`, `Velocity`, `Satellite`), and the service correctly sits dormant until D-Bus auto-activation, then comes up clean on demand — proper `Type=dbus` on-demand behavior, no manual steps.

### Part 3 — actually computing a fix (not just tracking satellites)

Confirmed via a real outdoor test that satellite tracking worked fine on its own (climbed to 6-8 satellites over several minutes) but `GetStatus` never advanced past "Acquiring" and position stayed empty. Turned out to be assistance-data related: this is a WiFi-only device with no cellular modem, and `geoclue-provider-hybris-binder` has two separate AGPS-assistance code paths — a cellular/QOfono one (permanently unavailable here) and a general-network NTP time-injection path that works over any online connection, gated by `NTP_FORCE_INJECT` in `/etc/gps_xtra.ini`. That config file simply didn't exist on this device, so the WiFi-capable assistance path was silently disabled.

**File added:** `/etc/gps_xtra.ini`:
```ini
[ntp]
NTP_FORCE_INJECT=true
```

### Testing

Three real outdoor tests over multiple sessions:
1. First test: no fix, traced to a test-tooling bug (each poll reconnecting to D-Bus, tearing down the GNSS session every ~37s — not a driver issue).
2. Second test, with the tooling fixed: real satellite tracking confirmed (6-8 satellites sustained over 5+ minutes) but no fix — led to the NTP config fix above.
3. Third test, 45 minutes, with the NTP fix in place: full success. Status reached "Available," 13-15 satellites tracked, and real coordinates updated continuously and consistently during an actual drive — a genuine moving GPS track, not a fluke reading.

Open item: no on-watch GPS visualization app currently launches cleanly on this device (a separate booster/IPC issue unrelated to GPS itself, not covered by this PR) — D-Bus polling against the geoclue interface is the practical way to confirm a fix in the meantime.
