### PR TITLE
hoki: audio: speaker and microphone working

### DIFF
--- a/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki/audio-firmware-hoki.service
+++ b/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki/audio-firmware-hoki.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Load hoki analog/digital codec and audio_machine kernel modules
+After=android-init.service tfa98xx-firmware-hoki.service
+Before=connman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/audio-firmware-hoki.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki/audio-firmware-hoki.sh
+++ b/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki/audio-firmware-hoki.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Load the audio_analog_cdc / audio_digital_cdc (legacy variant) codec modules
+# before audio_machine, which needs their exported msm_anlg_cdc_*/msm_digcdc_*
+# symbols. See https://github.com/AsteroidOS/meta-smartwatch (audio bring-up).
+
+modprobe audio_analog_cdc
+modprobe audio_digital_cdc
+modprobe audio_machine

--- a/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki_1.0.bb
+++ b/meta-hoki/recipes-core/audio-firmware-hoki/audio-firmware-hoki_1.0.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Loads the hoki analog/digital codec kernel modules before \
+audio_machine, which needs their exported msm_anlg_cdc_*/msm_digcdc_* \
+symbols."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://audio-firmware-hoki.sh;beginline=1;endline=2;md5=930f306dfea099b7fea2177393af6bd6"
+PR = "r0"
+
+SRC_URI = "file://audio-firmware-hoki.service \
+           file://audio-firmware-hoki.sh \
+           "
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "hoki"
+
+RDEPENDS:${PN} = "kernel-module-audio-analog-cdc kernel-module-audio-digital-cdc kernel-module-audio-machine"
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 audio-firmware-hoki.sh ${D}${bindir}
+
+    install -d ${D}/etc/systemd/system/multi-user.target.wants/
+    cp audio-firmware-hoki.service ${D}/etc/systemd/system/
+    ln -s ../audio-firmware-hoki.service ${D}/etc/systemd/system/multi-user.target.wants/audio-firmware-hoki.service
+}
+
+FILES:${PN} += "/etc/systemd/system/"

--- a/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki/audio-mixer-fix-hoki.service
+++ b/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki/audio-mixer-fix-hoki.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hoki audio mixer routing fix (speaker + mic DAPM routes)
+After=audio-firmware-hoki.service
+Requires=audio-firmware-hoki.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/audio-mixer-fix-hoki.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki/audio-mixer-fix-hoki.sh
+++ b/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki/audio-mixer-fix-hoki.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Poll for ALSA card 0 to actually be registered (fixed sleeps race the real
+# probe/enumeration time) before setting audio routing mixer controls.
+# Bounded retry, not an infinite loop.
+#
+# numid=348: QUAT_MI2S_RX -> MultiMedia1 (speaker playback route)
+# numid=1422: MultiMedia1 Mixer TERT_MI2S_TX (real mic capture backend -
+#             the correct, non-dummy digital-codec-backed capture path,
+#             NOT the QUAT_MI2S_TX dummy-codec route, and NOT the
+#             hw:0,11 "Hostless" device, which is architecturally
+#             incapable of host capture)
+# numid=83:  DEC1 MUX -> DMIC1 (selects the real digital mic as DEC1's
+#             input source)
+#
+# PulseAudio's own capture-direction device probing during startup resets
+# the mic-specific controls (1422, 83) but never touches the speaker
+# control (348, playback-only). Confirmed causally by masking
+# pulseaudio.service entirely and observing the mic controls hold
+# indefinitely with PA never running. Fix: wait for pulseaudio.service to
+# actually be active plus a settle buffer, THEN set all mixer controls
+# together at the end, so nothing is set-then-clobbered by PulseAudio's
+# own probing.
+
+i=0
+while [ $i -lt 60 ]; do
+	if [ -e /proc/asound/card0 ]; then
+		sleep 0.5
+		break
+	fi
+	i=$((i+1))
+	sleep 0.5
+done
+
+if [ ! -e /proc/asound/card0 ]; then
+	echo "audio-mixer-fix-hoki: TIMED OUT waiting for card 0" >> /tmp/audio-mixer-fix-hoki.log
+	exit 1
+fi
+echo "audio-mixer-fix-hoki: card0 present after ${i} x 0.5s polls" >> /tmp/audio-mixer-fix-hoki.log
+
+# Wait for pulseaudio.service (user session, ceres, uid 1000) to actually be
+# active before touching any of the mixer controls, since its startup/probe
+# resets them.
+j=0
+pa_active=0
+while [ $j -lt 40 ]; do
+	if su ceres -c 'systemctl --user is-active pulseaudio.service' 2>/dev/null | grep -q '^active$'; then
+		pa_active=1
+		break
+	fi
+	j=$((j+1))
+	sleep 0.5
+done
+echo "audio-mixer-fix-hoki: pulseaudio active=${pa_active} after ${j} x 0.5s polls" >> /tmp/audio-mixer-fix-hoki.log
+
+# Settle buffer: pulseaudio becoming "active" doesn't mean its own device
+# probing has finished yet. Empirically generous, not timing-critical.
+sleep 15
+
+amixer -c 0 cset numid=348 1,1 >>/tmp/audio-mixer-fix-hoki.log 2>&1
+amixer -c 0 cset numid=1422 1,1 >>/tmp/audio-mixer-fix-hoki.log 2>&1
+amixer -c 0 cset numid=83 DMIC1 >>/tmp/audio-mixer-fix-hoki.log 2>&1
+echo "audio-mixer-fix-hoki: all routes set (post-pulseaudio-settle)" >> /tmp/audio-mixer-fix-hoki.log
+
+exit 0

--- a/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki_1.0.bb
+++ b/meta-hoki/recipes-core/audio-mixer-fix-hoki/audio-mixer-fix-hoki_1.0.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "Sets the ALSA mixer routing controls hoki's speaker and \
+microphone need to actually route audio through DAPM, after waiting \
+for both ALSA card enumeration and PulseAudio's own startup probing to \
+settle (both were found to reset/race these controls if set too early)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://audio-mixer-fix-hoki.sh;beginline=1;endline=2;md5=930f306dfea099b7fea2177393af6bd6"
+PR = "r0"
+
+SRC_URI = "file://audio-mixer-fix-hoki.service \
+           file://audio-mixer-fix-hoki.sh \
+           "
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "hoki"
+
+RDEPENDS:${PN} = "audio-firmware-hoki alsa-utils-amixer"
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 audio-mixer-fix-hoki.sh ${D}${bindir}
+
+    install -d ${D}/etc/systemd/system/multi-user.target.wants/
+    cp audio-mixer-fix-hoki.service ${D}/etc/systemd/system/
+    ln -s ../audio-mixer-fix-hoki.service ${D}/etc/systemd/system/multi-user.target.wants/audio-mixer-fix-hoki.service
+}
+
+FILES:${PN} += "/etc/systemd/system/"

--- a/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki.service
+++ b/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Copy tfa98xx amp DSP firmware into place before audio modules load
+Before=audio-firmware-hoki.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/tfa98xx-firmware-hoki.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki.sh
+++ b/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Copy the real vendor tfa98xx amp DSP firmware container from the stock
+# Android /system partition into the path the kernel driver's
+# request_firmware() call actually looks under. Without this the amp's
+# fw-state stays "Stopped" and no calibrated audio path is available.
+
+mkdir -p /lib/firmware
+
+if [ -e /system/etc/firmware/tfa98xx.cnt ] && [ ! -e /lib/firmware/tfa98xx.cnt ]; then
+	cp /system/etc/firmware/tfa98xx.cnt /lib/firmware/tfa98xx.cnt
+fi

--- a/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki_1.0.bb
+++ b/meta-hoki/recipes-core/tfa98xx-firmware-hoki/tfa98xx-firmware-hoki_1.0.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Copies the tfa98xx smart speaker amp's onboard DSP firmware \
+container into the path the kernel driver's request_firmware() call \
+looks under. The real vendor file is present on the stock Android \
+/system partition (/system/etc/firmware/tfa98xx.cnt) but nothing \
+copies it into AsteroidOS's own /lib/firmware/ at boot."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://tfa98xx-firmware-hoki.sh;beginline=1;endline=2;md5=930f306dfea099b7fea2177393af6bd6"
+PR = "r0"
+
+SRC_URI = "file://tfa98xx-firmware-hoki.service \
+           file://tfa98xx-firmware-hoki.sh \
+           "
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "hoki"
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 tfa98xx-firmware-hoki.sh ${D}${bindir}
+
+    install -d ${D}/etc/systemd/system/multi-user.target.wants/
+    cp tfa98xx-firmware-hoki.service ${D}/etc/systemd/system/
+    ln -s ../tfa98xx-firmware-hoki.service ${D}/etc/systemd/system/multi-user.target.wants/tfa98xx-firmware-hoki.service
+}
+
+FILES:${PN} += "/etc/systemd/system/"

--- a/meta-hoki/recipes-kernel/linux/files/0007-pcm_native-guard-pm_qos_remove_request-with-active-.patch
+++ b/meta-hoki/recipes-kernel/linux/files/0007-pcm_native-guard-pm_qos_remove_request-with-active-.patch
@@ -1,0 +1,40 @@
+From: pettcomputers <chris@pettcomputers.com>
+Date: Tue, 2 Sep 2026 00:00:00 -0500
+Subject: [PATCH] pcm_native: guard pm_qos_remove_request with an active check
+ in snd_pcm_hw_free
+
+snd_pcm_hw_free() calls pm_qos_remove_request() unconditionally, while
+two other call sites in this same file (snd_pcm_release_substream and
+snd_pcm_hw_params) correctly guard the equivalent remove call with
+pm_qos_request_active() first. If hw_params ever skips its own
+conditional pm_qos_add_request() (a real, reachable path on hoki via
+the "Tertiary MI2S TX Hostless" PCM device, which never gets a real
+stream opened against it), hw_free's unconditional remove fires
+against a request that was never added, producing a kernel warning
+with a full backtrace.
+
+Found while debugging audio capture on hoki (Skagen Falster Gen 6) -
+see https://github.com/AsteroidOS/meta-smartwatch (audio bring-up).
+Confirmed via direct before/after dmesg comparison that the warning
+and backtrace are gone after this change, both immediately post-boot
+and after a settled retest.
+
+Signed-off-by: pettcomputers <chris@pettcomputers.com>
+---
+ sound/core/pcm_native.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/core/pcm_native.c b/sound/core/pcm_native.c
+index 7d9ef49..cfbf2b5 100644
+--- a/sound/core/pcm_native.c
++++ b/sound/core/pcm_native.c
+@@ -787,6 +787,7 @@ static int snd_pcm_hw_free(struct snd_pcm_substream *substream)
+ 	if (substream->ops->hw_free)
+ 		result = substream->ops->hw_free(substream);
+ 	snd_pcm_set_state(substream, SNDRV_PCM_STATE_OPEN);
++	if (pm_qos_request_active(&substream->latency_pm_qos_req))
+ 	pm_qos_remove_request(&substream->latency_pm_qos_req);
+ 	return result;
+ }
+--
+2.34.1

--- a/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
+++ b/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://github.com/fossil-engineering/kernel-msm-fossil-cw;branch=fossi
            file://0004-usb-hcd-Handle-when-host-mode-isn-t-available.patch \
            file://0005-initramfs-Don-t-skip-initramfs.patch \
            file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           file://0007-pcm_native-guard-pm_qos_remove_request-with-active-.patch \
            "
 
 SRCREV = "c0b4c201f2d5a641defe19958a9b4c16f40d866b"

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0006-fix-codec-subdir-recursion-gated-on-KERNEL_BUILD.patch
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki/0006-fix-codec-subdir-recursion-gated-on-KERNEL_BUILD.patch
@@ -1,0 +1,48 @@
+From: pettcomputers <chris@pettcomputers.com>
+Date: Mon, 31 Aug 2026 11:22:11 -0500
+Subject: [PATCH] fix: codec subdir recursion (wcd934x/sdm660_cdc/etc) gated
+ on KERNEL_BUILD==1, which never happens for external module builds since
+ MODNAME is always set
+
+asoc/codecs/Kbuild only recurses into wcd934x/, sdm660_cdc/, msm_sdw/
+and friends when KERNEL_BUILD==1 (an in-kernel-tree build). But the
+out-of-tree Makefile this recipe uses sets MODNAME globally, which
+makes KERNEL_BUILD always evaluate to 0 for this build - those
+subdirectories, including sdm660_cdc/ (which provides the
+msm_anlg_cdc_*/msm_dig_cdc_* symbols audio_machine.ko needs and was
+failing to load without), were structurally unreachable.
+
+Made the recursion unconditional. The actual per-module CONFIG_SND_SOC_*
+gates inside each subdir's own Kbuild are untouched and still apply
+correctly - this only fixes whether the build descends into the
+directory at all.
+
+Signed-off-by: pettcomputers <chris@pettcomputers.com>
+---
+ asoc/codecs/Kbuild | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/asoc/codecs/Kbuild b/asoc/codecs/Kbuild
+index ef8323c..0a4f5c1 100644
+--- a/asoc/codecs/Kbuild
++++ b/asoc/codecs/Kbuild
+@@ -6,7 +6,7 @@ else
+ 	KERNEL_BUILD := 0
+ endif
+
+-ifeq ($(KERNEL_BUILD), 1)
++ifeq (1, 1)
+ 	# These are configurable via Kconfig for kernel-based builds
+ 	# Need to explicitly configure for Android-based builds
+ 	AUDIO_BLD_DIR := $(shell pwd)/kernel/msm-4.14
+@@ -229,7 +229,7 @@ ifeq ($(KERNEL_BUILD), 0)
+   KBUILD_EXTRA_SYMBOLS +=$(AUDIO_KERNEL_OUT)/ipc/Module.symvers
+ endif
+
+-ifeq ($(KERNEL_BUILD), 1)
++ifeq (1, 1)
+ 	obj-y	+= wcd934x/
+ 	obj-y	+= sdm660_cdc/
+ 	obj-y	+= msm_sdw/
+--
+2.34.1

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bb
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bb
@@ -11,6 +11,7 @@ SRC_URI = "git://github.com/fossil-engineering/kernel-msm-fossil-extra-cw-audiok
            file://0003-Import-beluga-makefile.patch \
            file://0004-Ignore-compilation-warnings.patch \
            file://0005-dsp-Compile-codecs-for-out-of-tree-builds.patch \
+           file://0006-fix-codec-subdir-recursion-gated-on-KERNEL_BUILD.patch \
            "
 SRCREV = "c984389253fc58bc316af06bf3504dd2c25382be"
 LINUX_VERSION ?= "4.9"
@@ -19,7 +20,22 @@ B = "${S}"
 
 DEPENDS = "virtual/kernel"
 
-EXTRA_OEMAKE = " KERNEL_SRC="${STAGING_KERNEL_DIR}" M="${S}""
+# CONFIG_SND_SOC_ANALOG_CDC / CONFIG_SND_SOC_DIGITAL_CDC(_LEGACY) gate
+# asoc/codecs/sdm660_cdc/'s msm-analog-cdc.c / msm-digital-cdc(-legacy).c.
+# audio_machine.ko needs the msm_anlg_cdc_*/msm_digcdc_* symbols these
+# provide (the internal codec on this msm8937 platform) - without them
+# audio_machine fails to load with "Unknown symbol" errors.
+#
+# msm-digital-cdc.c (regular) and msm-digital-cdc-legacy.c (legacy) both
+# target the same output object and are meant to be mutually exclusive;
+# this board's machine driver (asoc/msm8952.c) calls into the legacy
+# variant's symbols specifically, so CONFIG_SND_SOC_DIGITAL_CDC is left
+# unset and only the _LEGACY variant is enabled.
+#
+# KCFLAGS (not EXTRA_CFLAGS - that silently breaks the kernel's own UAPI
+# header generation step) suppresses warnings-as-errors that the
+# newly-reachable codec files trip on this toolchain.
+EXTRA_OEMAKE = " KERNEL_SRC="${STAGING_KERNEL_DIR}" M="${S}" CONFIG_SND_SOC_ANALOG_CDC=m CONFIG_SND_SOC_DIGITAL_CDC= CONFIG_SND_SOC_DIGITAL_CDC_LEGACY=m KCFLAGS=-Wno-error"
 
 RPROVIDES:${PN} += "kernel-module-audio-apr"
 RPROVIDES:${PN} += "kernel-module-audio-pinctrl-wcd"
@@ -37,3 +53,5 @@ RPROVIDES:${PN} += "kernel-module-audio-wcd-core"
 RPROVIDES:${PN} += "kernel-module-audio-wsa881x-analog"
 RPROVIDES:${PN} += "kernel-module-audio-wcd9xxx"
 RPROVIDES:${PN} += "kernel-module-audio-platform"
+RPROVIDES:${PN} += "kernel-module-audio-analog-cdc"
+RPROVIDES:${PN} += "kernel-module-audio-digital-cdc"

--- a/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bbappend
+++ b/meta-hoki/recipes-kernel/modules/linux-audio-modules-hoki_p.bbappend
@@ -1,0 +1,1 @@
+S = "${UNPACKDIR}/git"

--- a/meta-hoki/recipes-multimedia/alsa/alsa-lib_%.bbappend
+++ b/meta-hoki/recipes-multimedia/alsa/alsa-lib_%.bbappend
@@ -1,0 +1,10 @@
+# HOKI FIX: this device's 2017-era kernel UAPI header predates ALSA's Y2038
+# time64 ABI transition (struct snd_pcm_sync_ptr etc.). Modern OE toolchains
+# define _TIME_BITS=64 by default, causing alsa-lib to compute a LARGER
+# struct snd_pcm_sync_ptr (136 bytes) than this kernel's own header expects
+# (132 bytes) -- the resulting SNDRV_PCM_IOCTL_SYNC_PTR ioctl numbers differ
+# (0xc0884123 vs 0xc0844123), so the kernel silently rejects every PCM
+# ioctl call from aplay/PulseAudio with -ENOTTY, since it never matches any
+# case in its switch statement. Undefine _TIME_BITS to fall back to the
+# legacy 32-bit time_t struct layout matching this kernel's own headers.
+CFLAGS:append = " -U_TIME_BITS"


### PR DESCRIPTION
## hoki: audio: speaker and microphone working

Fixes #343.

Following on from the WiFi (#224) and GPS (#252) work I posted separately — I've been chasing this on my own hoki (Skagen Falster Gen 6) and got both directions fully working — real audible playback (confirmed by actually listening to the watch, not just clean logs) and real microphone capture with genuine audio data. This ended up being a much deeper rabbit hole than WiFi or GPS, so writing it up in full since a lot of this wasn't documented anywhere I could find.



Worth flagging up front: this worked on my specific hoki (model DW13S1, the Skagen Falster Gen 6). The audio calibration data in particular (the `.acdb` file) is board-specific, and I don't know for sure whether the other hoki variants (Diesel, Fossil, Michael Kors) share the exact same speaker/mic hardware and calibration file or not. This is "worked for me," not a guarantee it's identical across every hoki model — if you're on a different variant and it doesn't work out of the box, the calibration data is probably the first place to check.

Also same as I said in #224 and #252: I used Claude Code to help me get through this one, and this was by far the deepest rabbit hole of the three (22 passes before speaker actually made sound). Not a kernel/audio developer by trade — sharing this back in case the specifics help someone else avoid retracing the same ground.

### The short version

There's real scaffolding for hoki audio already in the tree (`linux-audio-modules-hoki_p.bb`, a hoki-specific `pulseaudio_%.bbappend`) but the actual kernel codec driver was never being built at all — `audio_machine.ko` loaded with a pile of unresolved symbols (`msm_anlg_cdc_hs_detect`, `msm_digcdc_mclk_enable`, etc.) because the analog/digital codec source under `asoc/codecs/sdm660_cdc/` was structurally unreachable in this build. Once that's fixed and the module loads clean, there's a completely separate bug in `alsa-lib` itself that blocks every single playback attempt with `ENOTTY` before it even reaches the DSP layer. Fix that, and you're down to ALSA mixer routing (two different backends needed, one for speaker, a different one for mic) plus a couple of real boot-timing races to make it all persistent.

### Part 1 — kernel codec driver wasn't building at all

Three real, distinct build-system bugs in the vendor source, same general flavor as the WLAN Makefile bug from the WiFi thread — genuine defects in Fossil's out-of-tree build setup, not driver logic bugs:

1. `CONFIG_SND_SOC_ANALOG_CDC` / `CONFIG_SND_SOC_DIGITAL_CDC` were never set, so `asoc/codecs/sdm660_cdc/Kbuild`'s `obj-$(...)` lines never fired.
2. Even with those set, the subdirectory recursion into `sdm660_cdc/` (and its sibling codec dirs) is gated behind `ifeq ($(KERNEL_BUILD), 1)` in `asoc/codecs/Kbuild` — but the vendor's own imported top-level Makefile sets `MODNAME=audio` globally, which makes every sub-Kbuild's `KERNEL_BUILD` check evaluate false in this out-of-tree build context. That whole directory was structurally unreachable. Fixed with a one-line unconditional change on a locally-patched source snapshot (same pattern the WLAN driver already uses — stage a corrected copy, don't hand-edit `meta-smartwatch` upstream files directly).
3. `msm-digital-cdc.c` (regular) and `msm-digital-cdc-legacy.c` (legacy) both target the same output object and are meant to be mutually exclusive — enabling the digital codec config naively pulled in both and caused multiple-definition link errors. Checked which variant this board's actual machine driver (`asoc/msm8952.c`) calls into (`msm_digcdc_mclk_enable`, which only exists in the legacy variant) and set the Kconfig accordingly.

Recipe changes: `EXTRA_OEMAKE` additions in `linux-audio-modules-hoki_p.bb` for the Kconfig symbols plus `KCFLAGS=-Wno-error` (needed because the newly-reachable codec files trip a couple of warnings-as-errors on this toolchain — don't use `EXTRA_CFLAGS` for this, it silently breaks the kernel's own UAPI header generation step for unrelated reasons I didn't fully chase down; `KCFLAGS` is the correct Kbuild variable and doesn't have that side effect).

Confirmed via direct device testing across a real cold reboot: `audio_machine.ko` loads with zero unresolved symbols, a real `tfa98xx` amplifier IC registers on the I2C bus, and `/proc/asound/cards` shows a genuine registered soundcard with the full expected set of PCM device nodes under `/dev/snd/`.

### Part 2 — the actual playback blocker: an ABI mismatch in alsa-lib, not the DSP

This is the one that took the longest to find and matters most if anyone else hits it on similar hardware. Every `aplay` attempt failed with `ENOTTY` on `SNDRV_PCM_IOCTL_SYNC_PTR`, and I spent a long time chasing DSP calibration data (ACDB) as the cause before adding kernel printk instrumentation and discovering the ioctl never even reaches the DSP-facing code at all.

Root cause: our `alsa-lib` build (1.2.13) bundles its own copy of `asound.h` rather than using the kernel's, and that bundled header has a Y2038 "time64" ABI transition that changes `struct snd_pcm_sync_ptr`'s size depending on whether `__USE_TIME_BITS64` is set. Our Yocto toolchain passes `-D_TIME_BITS=64` to every `alsa-lib` compilation unit by default (a standard modern-Yocto default, nothing alsa-lib-specific), which selects the larger, newer struct layout — 136 bytes. This 2017-era kernel predates that transition entirely and only knows the 132-byte layout. Four bytes of struct-size mismatch, wrong ioctl number gets sent, kernel falls through to its unknown-ioctl default case and returns `ENOTTY`.

Fix is a targeted one-line recipe append, doesn't touch the distro-wide Y2038 setting:

`recipes-multimedia/alsa/alsa-lib_%.bbappend`:
```
CFLAGS:append = " -U_TIME_BITS"
```

Confirmed via direct dmesg comparison: before the fix, the ioctl sends as `0xc0884123` and gets rejected; after, it sends as `0xc0844123` (matching the kernel's own compiled value exactly) and succeeds. This is probably relevant to any hoki-family device running an older (pre-Y2038-transition) vendor kernel against a modern alsa-lib build — worth checking if anyone else hits an unexplained `ENOTTY` on `aplay`.

### Part 3 — mixer routing (two different backends, speaker vs mic)

Once the ioctl bug is fixed, playback still fails with a clean, readable kernel message: `ASoC: no backend DAIs enabled for MSM8952 Media1`. There's a real ALSA mixer switch that has to be explicitly enabled before the DAPM graph will route audio — `QUAT_MI2S_RX Audio Mixer MultiMedia1` for speaker (confirmed via `msm8952.c`'s DAI link table — this is the exact backend the tfa98xx DAI link uses).

Mic capture needed its own, different investigation — the obvious first attempt (`QUAT_MI2S_TX`, the capture-side mirror of the speaker's backend) turned out to be bound to a dummy stub codec in the vendor dai-links file, so it "worked" (clean capture, zero errors) but every sample was constant garbage. Traced the real signal path via the DAPM route table (`{"I2S TX1", NULL, "DEC1 MUX"}` in `msm-digital-cdc.c`, the genuine on-die digital codec) to a completely different, correctly-wired backend: `TERT_MI2S_TX` (frontend connector `MultiMedia1 Mixer TERT_MI2S_TX`), plus setting the `DEC1 MUX` input selector to `DMIC1`. Confirmed with real captured audio — genuine varying room-noise-floor data, not the constant value the dummy-codec route produced.

Also worth flagging in case anyone reuses `hw:0,11` ("Tertiary MI2S TX Hostless") off the device list — I initially assumed the name meant it was the real capture device. It's not; "Hostless" is a real Qualcomm term for DSP-internal backend-to-backend routing (FM loopback, voice-modem paths) with no host-readable data path at all, confirmed by reading `msm-pcm-hostless.c` directly (it implements `.prepare` only, nothing that could ever deliver samples to userspace). Don't waste time on it for capture.

### Part 4 — a couple of separate, real hardware/boot bugs found along the way

- **tfa98xx amp firmware was never loading.** The amp's own onboard DSP firmware container (`tfa98xx.cnt`) is sitting untouched on `/system/etc/firmware/` on the stock Android partition but was never copied to `/lib/firmware/` where the kernel driver's `request_firmware()` call looks. Same class of gap as the WiFi/GPS symlink fixes elsewhere in this device's bring-up. Fixed by copying it into place at image build/postinst time.
- **A real, permanent kernel bug in `sound/core/pcm_native.c`**: `snd_pcm_hw_free()` calls `pm_qos_remove_request()` unconditionally, while two other call sites in the same file correctly guard with `pm_qos_request_active()` first — if `hw_params` ever skipped its own conditional add, `hw_free`'s unconditional remove fires on a request that was never added, producing a kernel warning with a full backtrace. Added the same guard already used at the other two sites. This turned out to be cosmetic for the main playback path (it was firing during cleanup, not causing the failure), but it's a genuine bug worth fixing regardless, and it's the real blocker for the `hw:0,11` hostless path specifically if anyone does find a legitimate use for that device.

### Part 5 — making it stick across reboots

Two separate boot-timing races, both traced with real evidence rather than assumed:

1. **Card enumeration race**: the boot-time mixer-fix service used a fixed 2-second sleep before setting mixer controls, but ALSA card 0 isn't always registered by then — confirmed via the service's own journal showing `Invalid card number '0'` on a real cold boot. Replaced the fixed sleep with a bounded poll loop against `/proc/asound/card0`.
2. **PulseAudio startup resets mic-specific controls**: confirmed causally (not just correlated) by masking PulseAudio entirely and rebooting — with PulseAudio never starting, all mixer controls held correctly indefinitely. With PulseAudio running, mic-side controls got reset sometime during its startup/probing while the speaker control was untouched. Fixed by having the boot service wait for PulseAudio to report active, plus a settle buffer, then set all mixer controls together at the end rather than racing PulseAudio's own init.

Confirmed reliable across multiple real cold reboots and extended idle waits (3+ minutes), zero manual intervention required for either speaker or mic.

### Testing

- Speaker: confirmed by actually generating a tone and playing it through the watch, and hearing it.
- Mic: confirmed via captured data analysis (genuine varying room-noise-floor byte patterns, not the constant-value signature a wrong/dummy route produces) — haven't yet done a spoken-word round-trip test, but the data itself is clearly real audio, not silence or garbage.
- Both confirmed to survive a real cold reboot with zero manual steps.

Happy to split this into smaller PRs per subsystem if that's easier to review, or restructure however makes sense — this is a big one and I know it.

