### PR TITLE
sawfish: use the V2 AFE clock API for the internal codec core clock

### DIFF
--- a/meta-sawfish/recipes-android/android/android/60-i2c.rules
+++ b/meta-sawfish/recipes-android/android/android/60-i2c.rules
@@ -1,1 +1,9 @@
-KERNEL=="i2c-2", MODE="0666"
+# Allow pulseaudio to control I2C devices, for speaker.
+#
+# The Huawei Watch 2 speaker is driven by an NXP TFA98xx smart amplifier on
+# i2c-5 at address 0x34, which the vendor audio HAL drives directly over
+# /dev/i2c-5. PulseAudio runs as ceres, so without this the HAL fails with
+#   lxI2cInit: Can't open i2c bus:/dev/i2c-5
+# and module-droid-card never loads, leaving the watch with no audio devices
+# at all. This board has i2c-1, i2c-3 and i2c-5; there is no i2c-2.
+KERNEL=="i2c-5", GROUP="audio", MODE="0660"

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish/0012-dts-sawshark-drop-legacy-AFE-clock-version-so-audio-w.patch
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish/0012-dts-sawshark-drop-legacy-AFE-clock-version-so-audio-w.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Monperrus <martin.monperrus@gnieh.org>
+Date: Wed, 3 Sep 2026 22:30:00 +0200
+Subject: [PATCH] dts: sawshark: drop legacy AFE clock version so audio works
+
+The sound node inherits qcom,msm-afe-clk-ver = <1> from the Qualcomm
+reference include msm8909-mtp.dtsi. That makes msm8952.c take the legacy
+V1 branch in msm8952_enable_dig_cdc_clk() and friends:
+
+    if (pdata->afe_clk_ver == AFE_CLK_VERSION_V1)
+            ret = afe_set_digital_codec_core_clock(...);
+    else
+            ret = afe_set_lpass_clock_v2(...);
+
+The Q6 firmware on this watch rejects the V1 parameter
+AFE_PARAM_ID_INTERNAL_DIGIATL_CDC_CLK_CONFIG, so every attempt to start
+the internal codec core clock fails:
+
+    afe_set_digital_codec_core_clock: config cmd failed [ADSP_EBADPARAM]
+    failed to enable the MCLK
+    msm8952_enable_dig_cdc_clk: failed to enable CCLK
+    ASoC: TERTIARY_MI2S_TX startup failed: -22
+     TERTIARY_MI2S_TX: ASoC: BE open failed -22
+
+With no codec core clock there is no working audio path at all: the
+microphone backend never starts, and the NXP TFA98xx speaker amplifier
+on i2c-5 never receives a bit clock, so its PLL cannot lock and its
+SpeakerBoost cold start times out forever.
+
+Since msm8952_asoc_machine_probe() defaults to AFE_CLK_VERSION_V2 when
+the property is absent, simply deleting it in the board overlay selects
+afe_set_lpass_clock_v2() with
+Q6AFE_LPASS_CLK_ID_INTERNAL_DIGITAL_CODEC_CORE.
+
+Tested on a Huawei Watch 2 (sawfish). After this change every
+ADSP_EBADPARAM disappears, the microphone backend starts, and the
+amplifier reports PLLS and CLKS asserted during playback where it
+previously reported neither.
+
+Upstream-Status: Inappropriate [vendor kernel, board specific]
+---
+diff --git a/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-sound.dtsi b/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-sound.dtsi
+--- a/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-sound.dtsi
++++ b/arch/arm/boot/dts/apq8009w-sawshark/apq8009w-sound.dtsi
+@@ -32,6 +32,18 @@
+ 	pinctrl-2 = <&cdc_pdm_lines_sus &cdc_ext_tlmm_act>;
+ 	pinctrl-3 = <&cdc_pdm_lines_act &cdc_ext_tlmm_act>;
+ 	/delete-property/ qcom,cdc-us-euro-gpios;
++	/*
++	 * msm8909-mtp.dtsi sets qcom,msm-afe-clk-ver = <1>, which makes
++	 * msm8952.c use the legacy afe_set_digital_codec_core_clock()
++	 * call. The Q6 firmware on this watch rejects that parameter
++	 * (AFE_PARAM_ID_INTERNAL_DIGIATL_CDC_CLK_CONFIG) with
++	 * ADSP_EBADPARAM, so the internal codec core clock never starts
++	 * and neither the speaker nor the microphone works. Dropping the
++	 * property makes the driver default to AFE_CLK_VERSION_V2 and use
++	 * afe_set_lpass_clock_v2() with
++	 * Q6AFE_LPASS_CLK_ID_INTERNAL_DIGITAL_CODEC_CORE instead.
++	 */
++	/delete-property/ qcom,msm-afe-clk-ver;
+ };
+ &soc{
+ 	qcom,msm-dai-mi2s {

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
@@ -23,6 +23,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-sawshark
            file://0010-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
            file://00011-dts-sawshark-Remove-USB-gadget-function-list.patch \
            file://0011-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           file://0012-dts-sawshark-drop-legacy-AFE-clock-version-so-audio-w.patch \
            "
 
 SRCREV = "66cf3d5be07a599af417695e4f22f304af667979"


### PR DESCRIPTION
sawfish: use the V2 AFE clock API for the internal codec core clock

Huawei Watch 2: the audio stack does not work, see https://github.com/AsteroidOS/asteroid/issues/101#issuecomment-846983622 and https://github.com/AsteroidOS/meta-smartwatch/issues/340

## Root cause

The sound node inherits qcom,msm-afe-clk-ver = <1> from the Qualcomm
reference include msm8909-mtp.dtsi, which makes msm8952.c take the legacy
branch and call afe_set_digital_codec_core_clock(). The Q6 firmware on this
watch rejects that parameter with ADSP_EBADPARAM, so the internal codec core
clock never starts:

    afe_set_digital_codec_core_clock: config cmd failed [ADSP_EBADPARAM]
    failed to enable the MCLK
    msm8952_enable_dig_cdc_clk: failed to enable CCLK
    ASoC: TERTIARY_MI2S_TX startup failed: -22
     TERTIARY_MI2S_TX: ASoC: BE open failed -22

Without that clock there is no working audio path at all. The microphone
backend never starts, and the TFA98xx speaker amplifier never receives a bit
clock, so its PLL cannot lock and its cold start times out forever.

## Fix

msm8952_asoc_machine_probe() defaults to AFE_CLK_VERSION_V2 when the property
is absent, so deleting it in the board overlay selects
afe_set_lpass_clock_v2() with Q6AFE_LPASS_CLK_ID_INTERNAL_DIGITAL_CODEC_CORE.

Separately, 60-i2c.rules targets i2c-2, which does not exist on this board.
The speaker's TFA98xx amplifier is on i2c-5 at 0x34, which the vendor audio
HAL opens directly, and PulseAudio runs as ceres. Without the corrected rule
the HAL fails with "Can't open i2c bus:/dev/i2c-5", module-droid-card never
loads, and PulseAudio comes up with only a null sink. The recipe comment
already says the rule exists to let PulseAudio reach the speaker; only the bus
number was wrong. The mode is also narrowed from world-writable to the audio
group, which ceres is already in.

## Validation 

Tested on a Huawei Watch 2 end to end. Every ADSP_EBADPARAM disappears, and
the amplifier reports PLLS and CLKS asserted during playback.

Microphone works. Speaker produces sound, but the TFA98xx SpeakerBoost
startup still needs SBSL set over i2c once per playback, because the vendor
HAL only attempts it at adev_open, when no stream and therefore no bit clock
exists, and never retries. Procedure and tooling:
https://github.com/monperrus/asteroid-sawfish-audio
