### PR TITLE
minnow: Fix enabling/disabling Bluetooth sometimes resulting in a crash

### DIFF
--- a/meta-minnow/recipes-kernel/linux/linux-minnow/0016-misc-st_core-Fix-skb-double-free-corruption.patch
+++ b/meta-minnow/recipes-kernel/linux/linux-minnow/0016-misc-st_core-Fix-skb-double-free-corruption.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pengcheng Li <lipengcheng8@huawei.com>
+Date: Sat, 28 Apr 2018 02:16:11 -0400
+Subject: [PATCH] misc: st_core: Fix skb double free corruption
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When some failures happened in hci_recv_frame() function,
+skb is freed by both hci_recv_frame and st_send_frame
+
+Signed-off-by: Li Pengcheng <lipengcheng8@huawei.com>
+Signed-off-by: Yao Baofeng <yaobaofeng@huawei.com>
+Signed-off-by: Li Jiangxiong <lijiangxiong@huawei.com>
+Upstream-Status: Inappropriate [driver removed from mainline]
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+[ regenerated against 3.10: the archive mangled tabs and the pr_err() string differs ]
+---
+ drivers/misc/ti-st/st_core.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/misc/ti-st/st_core.c b/drivers/misc/ti-st/st_core.c
+index 92449a6a1d6b..ff5c81ae39d4 100644
+--- a/drivers/misc/ti-st/st_core.c
++++ b/drivers/misc/ti-st/st_core.c
+@@ -132,7 +132,6 @@
+ 			(st_gdata->list[chnl_id]->priv_data, st_gdata->rx_skb)
+ 			     != 0)) {
+ 			pr_err("proto stack %d's ->recv failed\n", chnl_id);
+-			kfree_skb(st_gdata->rx_skb);
+ 			return;
+ 		}
+ 	} else {
+-- 
+2.8.0
+

--- a/meta-minnow/recipes-kernel/linux/linux-minnow_mm-mr1.bb
+++ b/meta-minnow/recipes-kernel/linux/linux-minnow_mm-mr1.bb
@@ -29,6 +29,7 @@ SRC_URI = " git://android.googlesource.com/kernel/omap;branch=android-omap-minno
     file://0013-Revert-Bluetooth-Keep-master-role-when-SCO-or-eSCO-i.patch \
     file://0014-Backport-mainline-4.1-Bluetooth-subsystem.patch \
     file://0015-ARM-omap2-minnow-register-btwilink-platform-device.patch \
+    file://0016-misc-st_core-Fix-skb-double-free-corruption.patch \
     file://defconfig \
     file://img_info \
 "


### PR DESCRIPTION
Turning Bluetooth off or on sometimes resulted in the watch crashing.

st_send_frame() frees st_gdata->rx_skb when the protocol's ->recv() fails. For Bluetooth that is btwilink, which passes the skb to hci_recv_frame(). While the hci_dev is neither HCI_UP nor HCI_INIT, hci_recv_frame() frees the skb and returns an error. btwilink passes the error back, and st_send_frame() frees the skb a second time. The second free corrupts whatever reuses the skb's memory, eventually resulting in a crash.

Link: https://lkml.iu.edu/hypermail/linux/kernel/1804.3/05197.html